### PR TITLE
sparkmonitor: Fix for Spark 3.0.1: use attemptNumber instead of attemptId

### DIFF
--- a/SparkMonitor/scalalistener/CustomListener.scala
+++ b/SparkMonitor/scalalistener/CustomListener.scala
@@ -169,7 +169,7 @@ class JupyterSparkMonitorListener(conf: SparkConf) extends SparkListener {
     val submissionTime: Long = stageInfo.submissionTime.getOrElse(-1)
 
     (stageInfo.stageId.toString ->
-      ("attemptId" -> stageInfo.attemptId) ~
+      ("attemptId" -> stageInfo.attemptNumber) ~
       ("name" -> stageInfo.name) ~
       ("numTasks" -> stageInfo.numTasks) ~
       ("completionTime" -> completionTime) ~
@@ -217,7 +217,7 @@ class JupyterSparkMonitorListener(conf: SparkConf) extends SparkListener {
     // so that we can display stage descriptions for pending stages:
     for (stageInfo <- jobStart.stageInfos) {
       stageIdToInfo.getOrElseUpdate(stageInfo.stageId, stageInfo)
-      stageIdToData.getOrElseUpdate((stageInfo.stageId, stageInfo.attemptId), new StageUIData)
+      stageIdToData.getOrElseUpdate((stageInfo.stageId, stageInfo.attemptNumber), new StageUIData)
     }
     val name = jobStart.properties.getProperty("callSite.short", "null")
     val json = ("msgtype" -> "sparkJobStart") ~
@@ -295,7 +295,7 @@ class JupyterSparkMonitorListener(conf: SparkConf) extends SparkListener {
   override def onStageCompleted(stageCompleted: SparkListenerStageCompleted): Unit = synchronized {
     val stage = stageCompleted.stageInfo
     stageIdToInfo(stage.stageId) = stage
-    val stageData = stageIdToData.getOrElseUpdate((stage.stageId, stage.attemptId), {
+    val stageData = stageIdToData.getOrElseUpdate((stage.stageId, stage.attemptNumber), {
       logger.info("Stage completed for unknown stage " + stage.stageId)
       new StageUIData
     })
@@ -332,7 +332,7 @@ class JupyterSparkMonitorListener(conf: SparkConf) extends SparkListener {
     val submissionTime: Long = stage.submissionTime.getOrElse(-1)
     val json = ("msgtype" -> "sparkStageCompleted") ~
       ("stageId" -> stage.stageId) ~
-      ("stageAttemptId" -> stage.attemptId) ~
+      ("stageAttemptId" -> stage.attemptNumber) ~
       ("completionTime" -> completionTime) ~
       ("submissionTime" -> submissionTime) ~
       ("numTasks" -> stage.numTasks) ~
@@ -353,7 +353,7 @@ class JupyterSparkMonitorListener(conf: SparkConf) extends SparkListener {
     activeStages(stage.stageId) = stage
     pendingStages.remove(stage.stageId)
     stageIdToInfo(stage.stageId) = stage
-    val stageData = stageIdToData.getOrElseUpdate((stage.stageId, stage.attemptId), new StageUIData)
+    val stageData = stageIdToData.getOrElseUpdate((stage.stageId, stage.attemptNumber), new StageUIData)
     stageData.description = Option(stageSubmitted.properties).flatMap {
       p => Option(p.getProperty("spark.job.description"))
     }
@@ -372,7 +372,7 @@ class JupyterSparkMonitorListener(conf: SparkConf) extends SparkListener {
     val submissionTime: Long = stage.submissionTime.getOrElse(-1)
     val json = ("msgtype" -> "sparkStageSubmitted") ~
       ("stageId" -> stage.stageId) ~
-      ("stageAttemptId" -> stage.attemptId) ~
+      ("stageAttemptId" -> stage.attemptNumber) ~
       ("name" -> stage.name) ~
       ("numTasks" -> stage.numTasks) ~
       ("parentIds" -> stage.parentIds) ~
@@ -389,12 +389,12 @@ class JupyterSparkMonitorListener(conf: SparkConf) extends SparkListener {
   def onStageStatusActive(): Unit = {
     // Update on status of active stages
     for ((stageId, stageInfo) <- activeStages) {
-      val stageData = stageIdToData.getOrElseUpdate((stageInfo.stageId, stageInfo.attemptId), new StageUIData)
+      val stageData = stageIdToData.getOrElseUpdate((stageInfo.stageId, stageInfo.attemptNumber), new StageUIData)
       val jobIds = stageIdToActiveJobIds.get(stageInfo.stageId)
       
       val json = ("msgtype" -> "sparkStageActive") ~
         ("stageId" -> stageInfo.stageId) ~
-        ("stageAttemptId" -> stageInfo.attemptId) ~
+        ("stageAttemptId" -> stageInfo.attemptNumber) ~
         ("name" -> stageInfo.name) ~
         ("parentIds" -> stageInfo.parentIds) ~
         ("numTasks" -> stageInfo.numTasks) ~
@@ -606,7 +606,7 @@ class JupyterSparkMonitorListener(conf: SparkConf) extends SparkListener {
     if (stages.size > retainedStages) {
       val toRemove = calculateNumberToRemove(stages.size, retainedStages)
       stages.take(toRemove).foreach { s =>
-        stageIdToData.remove((s.stageId, s.attemptId))
+        stageIdToData.remove((s.stageId, s.attemptNumber))
         stageIdToInfo.remove(s.stageId)
       }
       stages.trimStart(toRemove)

--- a/SparkMonitor/scalalistener/build.sbt
+++ b/SparkMonitor/scalalistener/build.sbt
@@ -2,11 +2,11 @@ name := "sparkmonitor"
 
 version := "1.0"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.0"
 
 organization := "cern"
 
-val sparkVersion = "2.1.1"
+val sparkVersion = "3.0.1"
 
 libraryDependencies ++= List(
   "org.apache.spark" %% "spark-core" % sparkVersion,


### PR DESCRIPTION
Attempting to use `sparkmonitor` (either the original one or the fork in this repo) with Spark 2.4.7 works (at least in this tree https://github.com/pwais/oarphpy/tree/v0.0.4 ), but with Spark 3.0.1 one runs into this error:
```
INFO:SparkMonitorKernel:Client Connected ('127.0.0.1', 43708)
2020-09-26 06:54:06,315 ERROR util.Utils: uncaught error in thread spark-listener-group-shared, stopping SparkContext
java.lang.IllegalAccessError: class sparkmonitor.listener.JupyterSparkMonitorListener tried to access private method 'int org.apache.spark.scheduler.StageInfo.attemptId()' (sparkmonitor.listener.JupyterSparkMonitorListener and org.apache.spark.scheduler.StageInfo are in unnamed module of loader 'app')
        at sparkmonitor.listener.JupyterSparkMonitorListener.stageInfoToJSON(CustomListener.scala:172)
        at sparkmonitor.listener.JupyterSparkMonitorListener$$anonfun$onJobStart$4.apply(CustomListener.scala:204)
        at sparkmonitor.listener.JupyterSparkMonitorListener$$anonfun$onJobStart$4.apply(CustomListener.scala:203)
        ...
        at scala.util.DynamicVariable.withValue(DynamicVariable.scala:62)
        at org.apache.spark.scheduler.AsyncEventQueue.org$apache$spark$scheduler$AsyncEventQueue$$dispatch(AsyncEventQueue.scala:100)
        at org.apache.spark.scheduler.AsyncEventQueue$$anon$2.$anonfun$run$1(AsyncEventQueue.scala:96)
        at org.apache.spark.util.Utils$.tryOrStopSparkContext(Utils.scala:1319)
        at org.apache.spark.scheduler.AsyncEventQueue$$anon$2.run(AsyncEventQueue.scala:96)
```

While it appears `attemptId` was made private years ago ( https://github.com/apache/spark/commit/32365f8177f913533d348f7079605a282f1014ef#diff-e3e46893527ae54411257d6fb1d73964 ), nevertheless you can see in the javadocs that `attemptId` is gone in Spark 3.x and they want people to use `attemptNumber`:
 * Spark 2.4.7: https://spark.apache.org/docs/2.4.7/api/java/org/apache/spark/scheduler/StageInfo.html
 * Spark 3.x (latest): https://spark.apache.org/docs/latest/api/java/org/apache/spark/scheduler/StageInfo.html


This change includes the following fixes:
 * Use `attemptNumber` instead of `attemptId`.  I'm not sure how (if at all) the semantics differ, but I imagine the end-user impacts will be minimal.  In my own experience debugging spark jobs, if I have to be very nitty gritty I'll try to get the raw logs from the executor or history server.
 * Sets up the scala listener to build against Spark 3.0.1 (which appears to require updating to scala 2.12.  For whatever reason, I could not get the listener to build against Spark 2.1.1 as-is.  Building against Spark 2.7.4 does appear to work.

So far I've only tested this manually, not sure what sort of automated testing might be available.