### PR TITLE
Added support to activate a workflow systemuser-image

### DIFF
--- a/.github/workflows/swan-ci-ca.yml
+++ b/.github/workflows/swan-ci-ca.yml
@@ -108,10 +108,11 @@ jobs:
         draft: false
         prerelease: false
 
-#    - name: Invoke workflow in systemuser-image
-#      uses: benc-uk/workflow-dispatch@v1
-#      with:
-#        workflow: SWAN CI/CD pipeline
-#        repo: swan-cern/systemuser-image
-#        token: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}
-#        inputs: '{ "package": "${{env.PACKAGE_NAME}}", "version": "${{env.PACKAGE_VERSION}}" }'
+    - name: Invoke workflow in systemuser-image
+      uses: benc-uk/workflow-dispatch@v1
+      with:
+        workflow: SWAN CI/CD pipeline
+        ref: master
+        repo: swan-cern/jupyter-extensions
+        token: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}
+        inputs: '{ "package": "${{env.PACKAGE_NAME}}", "version": "${{env.PACKAGE_VERSION}}" }'


### PR DESCRIPTION
This is to change the version of the extension in systemuser-image.

The secret WORKFLOW_ACCESS_TOKEN must be a [PAT](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) this is required for the module benc-uk/workflow-dispatch@v1 