### PR TITLE
Fix python3.6 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 !SwanContents/swancontents/js/
 SparkMonitor/scalalistener/project/
 SparkMonitor/scalalistener/target/
-SparkMonitor/sparkmonitor/listener.jar
+SparkMonitor/sparkmonitor/listener*.jar
 SparkMonitor/sparkmonitor/nbextension/*
 .idea/
 

--- a/SparkMonitor/sparkmonitor/kernelextension.py
+++ b/SparkMonitor/sparkmonitor/kernelextension.py
@@ -175,14 +175,14 @@ def load_ipython_extension(ipython):
 
 
 def configure(conf):
-    """Configures the provided conf object. 
+    """Configures the provided conf object.
 
     Sets the Java Classpath and listener jar file path to "conf".
     Also sets an environment variable for ports for communication with scala listener.
     """
     global monitor
     port = monitor.getPort()
-    log.info("SparkConf Configured, Starting to listen on port:", str(port))
+    log.info("SparkConf Configured, Starting to listen on port: %s", str(port))
     os.environ["SPARKMONITOR_KERNEL_PORT"] = str(port)
     log.info(os.environ["SPARKMONITOR_KERNEL_PORT"])
     conf.set("spark.extraListeners",
@@ -203,5 +203,5 @@ def sendToFrontEnd(msg):
 
 def get_spark_version():
     cmd = "pyspark --version 2>&1 | grep -m 1  -Eo '[0-9]*[.][0-9]*[.][0-9]*[,]' | sed 's/,$//'"
-    version = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    version = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8")
     return version.stdout.strip()


### PR DESCRIPTION
Hello.

According to setup.py file of SparkMonitor, minimal supported version of Python is 3.5.
But when I tried to run it on python3.6, an exception has been raised:
```
  File "/opt/anaconda2/envs/jh-py36/env/lib64/python3.6/subprocess.py", line 403, in run
    with Popen(*popenargs, **kwargs) as process:
TypeError: __init__() got an unexpected keyword argument 'capture_output'
```
`capture_output` argument was added  to python 3.7+ and it does not exist on python 3.6. In this PR I fixed this compatibility issue.

But after fixing it I've received another exception:
```
  File "/opt/anaconda2/envs/jh-py36/env/lib64/python3.6/site-packages/sparkmonitor/kernelextension.py", line 185, in configure
    log.info("SparkConf Configured, Starting to listen on port:", str(port))
Message: 'SparkConf Configured, Starting to listen on port:'
Arguments: ('56189',)
```
It is because the string format in the log line has no substitutions, but some value is passed into it. This error is fixed too.
