### PR TITLE
ITHADOOP-1020: Configure shuffle for Spark 3.x on K8s

### DIFF
--- a/SparkConnector/sparkconnector/configuration.py
+++ b/SparkConnector/sparkconnector/configuration.py
@@ -245,6 +245,11 @@ class SparkK8sConfiguration(SparkConfiguration):
         conf.set('spark.kubernetes.namespace', os.environ.get('SPARK_USER'))
         conf.set('spark.master', self._retrieve_k8s_master(os.environ.get('KUBECONFIG')))
 
+        # Configure shuffle if running on K8s with Spark 3.x.x
+        if self.get_spark_version().split('.')[0]=='3':
+            conf.set('spark.shuffle.service.enabled', 'false')
+            conf.set('spark.dynamicAllocation.shuffleTracking.enabled', 'true')
+
         # Ensure that Spark ENVs on executors are the same as on the driver
         conf.set('spark.executorEnv.PYTHONPATH', os.environ.get('PYTHONPATH'))
         conf.set('spark.executorEnv.JAVA_HOME', os.environ.get('JAVA_HOME'))


### PR DESCRIPTION
This PR moves the options in the Spark3Shuffle bundle, to be hardcoded on the connector for Spark 3 running on K8s (cloud containers cluster). (These options need to be set always for Spark3 on K8s for dynamic resource allocation to work without an external shuffle service)

Ideally this config could live near `gitlab/db/hadoop-confext/conf/etc/analytix/spark3.analytix/spark-defaults.conf`, but these options are specific to Spark on K8s only.