### PR TITLE
[ITHADOOP-1024] Remove check on spark.jars.packages for Spark on K8S

### DIFF
--- a/SparkConnector/sparkconnector/configuration.py
+++ b/SparkConnector/sparkconnector/configuration.py
@@ -287,10 +287,6 @@ class SparkK8sConfiguration(SparkConfiguration):
                 conf.get('spark.yarn.dist.archives', None):
             raise Exception('Kubernetes does not support syntax for YARN, use spark.files or spark.jars')
 
-        if conf.get('spark.jars.packages', None):
-            raise Exception('Kubernetes currently does not support spark.jars.packages as of Spark 2.4. '
-                            'Please use spark.jars and http:// for downloading required jars.')
-
         return conf
 
     def get_spark_session_config(self):


### PR DESCRIPTION
Spark on K8S version 2.4 does not support --packages (confing parameter spark.jars.packages).
The Spark connector in SWAN throws an error, signaling this.
Spark 3.x supports the use of spark.jars.packages (in client mode).
As we have now moved to Spark 3.0.1 in LCG 99 and Spark 3.1.1 in future LCG 100, this updates the SWAN connector removing the check so that we can use the new functionality.