### PR TITLE
SwanContents: fix change config url for deployments with different base path

### DIFF
--- a/SwanContents/swancontents/templates/page.html
+++ b/SwanContents/swancontents/templates/page.html
@@ -226,7 +226,7 @@ dir="ltr">
                     'Change': {
                         class: 'btn-warning',
                         click: function () {
-                            window.location.replace('/hub/home?changeconfig');
+                            window.location.replace('{{hub_prefix}}home?changeconfig');
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #144

Unlike what I say in the ticket, I just did a small fix without going into wether this is a named server setup or not.