### PR TITLE
SwanContents LAB3 updates

### DIFF
--- a/SwanContents/setup.py
+++ b/SwanContents/setup.py
@@ -55,7 +55,6 @@ setup_args = dict(
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/SwanContents/setup.py
+++ b/SwanContents/setup.py
@@ -41,7 +41,7 @@ setup_args = dict(
     cmdclass= cmdclass,
     packages=setuptools.find_packages(),
     install_requires=[
-          'notebook==6.1.*',
+          'notebook==6.4.*',
           'tornado',
           'jupyter_core',
           'requests'

--- a/SwanContents/swancontents/filemanager/swanfilemanager.py
+++ b/SwanContents/swancontents/filemanager/swanfilemanager.py
@@ -178,11 +178,10 @@ class SwanFileManager(SwanFileManagerMixin, LargeFileManager):
 
         os_path_proj = self._get_os_path(os.path.join(path, self.swan_default_file))
 
-        if os.path.isdir(os_path) and os.path.isfile(os_path_proj):
+        if os.path.isdir(os_path) and os.path.isfile(os_path_proj) and self._is_swan_root_folder(os_path):
             if type not in (None, 'project', 'directory'):
                 raise web.HTTPError(400,
                                 u'%s is a project, not a %s' % (path, type), reason='bad type')
-
             model = self._proj_model(path, content=content)
 
         else:


### PR DESCRIPTION
Hi Guys,

some updates for SwanContents, 
to be consistent with all the components at the moment the project can only exist in the
SWAN_projects folder, others folder outside this folder with the file .swanproject is not a project.

Also updated notebook version, compatible with lab 3.0.x

Tested in swan-spare001  please take a look there.