### PR TITLE
Fixes to swancontents

### DIFF
--- a/SwanContents/setup.py
+++ b/SwanContents/setup.py
@@ -41,7 +41,7 @@ setup_args = dict(
     cmdclass= cmdclass,
     packages=setuptools.find_packages(),
     install_requires=[
-          'notebook==6.1.*',
+          'notebook==6.4.*',
           'tornado',
           'jupyter_core',
           'requests'

--- a/SwanContents/swancontents/filemanager/swanfilemanager.py
+++ b/SwanContents/swancontents/filemanager/swanfilemanager.py
@@ -83,9 +83,9 @@ class SwanFileManager(SwanFileManagerMixin, LargeFileManager):
         model = super(LargeFileManager, self)._dir_model(path, content)
         parent_project = self._get_project_path(path)
 
+        model['is_project'] = False
         if parent_project and not parent_project == 'invalid':
             model['project'] = parent_project
-            model['is_project'] = False
 
         return model
 
@@ -211,7 +211,7 @@ class SwanFileManager(SwanFileManagerMixin, LargeFileManager):
         self.run_pre_save_hook(model=model, path=path)
 
         try:
-            if model['type'] == 'project':
+            if 'is_project' in model and model['is_project']:
                 if not self._is_swan_root_folder(os_path):
                     raise web.HTTPError(400, "You can only create projects inside Swan Projects")
                 self._save_project(os_path, model, path)
@@ -298,16 +298,14 @@ class SwanFileManager(SwanFileManagerMixin, LargeFileManager):
         if type:
             model['type'] = type
 
-        model['is_project'] = False
-
         if ext == '.ipynb':
             model.setdefault('type', 'notebook')
         else:
             model.setdefault('type', 'file')
-
         insert = ''
         if model['type'] == 'directory':
             untitled = self.untitled_directory
+            model['is_project'] = False
             insert = ' '
 
         elif model['type'] == 'project':

--- a/SwanContents/swancontents/templates/tree.html
+++ b/SwanContents/swancontents/templates/tree.html
@@ -447,7 +447,9 @@ data-server-root="{{server_root}}"
 
 {% block script %}
     {{super()}}
+    <script src="{{ static_url("tree/js/main.min.js") }}" type="text/javascript" charset="utf-8"></script>
 
-
-<script src="{{ static_url("tree/js/main.min.js") }}" type="text/javascript" charset="utf-8"></script>
+    <script type="text/javascript">
+      $('#element').tooltip('enable')
+    </script>
 {% endblock %}

--- a/SwanShare/src/extension.js
+++ b/SwanShare/src/extension.js
@@ -330,7 +330,7 @@ function start_notebook_view() {
 
                 $.get(folder_path, function (folder) {
 
-                    if (folder.type === 'project') {
+                    if (folder.is_project) {
                         modal.show_share_modal(folder.path);
                     } else if (folder.type === 'directory' && folder.project) {
                         modal.show_share_modal(folder.project);


### PR DESCRIPTION
* Workaround for checkpoints failure preventing opening notebooks via JupyterLab
* Update to latest upstream (6.4.0)
*  Fixes to bugs introduced in #92:
  * impossibility to share in the notebook editor (#124)
  * creating un-named projects just creates a folder and not a project (#194)

Fix #124
Fix #194