### PR TITLE
SwanDask: wrapper to dask-labextension

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,13 @@
+[flake8]
+ignore = E501, W503, E402
+builtins = c, get_config
+exclude =
+    .cache,
+    .github,
+    docs,
+    setup.py
+enable-extensions = G
+extend-ignore =
+    G001, G002, G004, G200, G201, G202,
+    # black adds spaces around ':'
+    E203,

--- a/.gitignore
+++ b/.gitignore
@@ -262,3 +262,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Mac OS files
+.DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,54 @@
+ci:
+  # skip any check that needs internet access
+  skip: [check-jsonschema, prettier, eslint, stylelint, integrity]
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: forbid-new-submodules
+      - id: end-of-file-fixer
+      - id: check-case-conflict
+      - id: check-executables-have-shebangs
+      - id: requirements-txt-fixer
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-toml
+      - id: check-yaml
+      - id: debug-statements
+      - id: check-builtin-literals
+      - id: trailing-whitespace
+        exclude: .bumpversion.cfg
+
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        args: ["--line-length", "100"]
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        files: \.py$
+        args: [--profile=black]
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          [
+            "flake8-bugbear==20.1.4",
+            "flake8-logging-format==0.6.0",
+            "flake8-implicit-str-concat==0.2.0",
+          ]
+
+  - repo: https://github.com/sirosen/check-jsonschema
+    rev: 0.10.2
+    hooks:
+      - id: check-jsonschema
+        name: 'Check GitHub Workflows'
+        files: ^\.github/workflows/
+        types: [yaml]
+        args: ['--schemafile', 'https://json.schemastore.org/github-workflow']

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Repository that stores all the Jupyter extensions for SWAN.
 * [SparkConnector](SparkConnector) - Helper to connect to CERN's Spark Clusters
 * [SparkMonitor](SparkMonitor) - Live monitoring of Apache Spark Jobs spawned from a notebook
 * [SwanContents](SwanContents) - Contents Manager for Jupyter with Projects functionality and SWAN templates
+* [SwanDask](SwanDask) - Wrapper to run dask_jupyterlab as an external process
 * [SwanHelp](SwanHelp) - SWAN Help panel for Notebooks and Lab
 * [SwanIntro](SwanIntro) - Extension to display to users what has changed since the last time they used the service (or greet new users)
 * [SwanKernelEnv](SwanKernelEnv) - Kernel extension to remove SWAN special paths from the user environment (thus keeping the clean LCG release environment)

--- a/SwanDask/.bumpversion.cfg
+++ b/SwanDask/.bumpversion.cfg
@@ -1,0 +1,8 @@
+[bumpversion]
+current_version = 0.0.0
+commit = True
+tag = True
+tag_name = SwanDask/v{new_version}
+message = SwanDask v{new_version}
+
+[bumpversion:file:swandask/_version.py]

--- a/SwanDask/MANIFEST.in
+++ b/SwanDask/MANIFEST.in
@@ -1,0 +1,10 @@
+include LICENSE
+include README.md
+include pyproject.toml
+
+# Patterns to exclude from any directory
+global-exclude *~
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude .git
+global-exclude .ipynb_checkpoints

--- a/SwanDask/README.md
+++ b/SwanDask/README.md
@@ -1,0 +1,19 @@
+# SwanDask
+
+This module is a wrapper to the [dask-labextension](https://github.com/dask/dask-labextension) extension.
+It allows running the backend as a separate process, served via jupyter-server-proxy, instead of a server extension.
+
+We use it to configure the Dask environment, which we want to be different than the process running Jupyter Lab.
+
+The extension will automatically load the environment from the default Python 3 kernel.
+
+
+## Install
+
+```
+pip install swandask
+```
+
+If being served under an LCG release, install the package without any dependency except Jupyter and `jupyter-server-proxy`.
+
+This extension needs to be installed *after* its dependency `dask-labextension` in order to disable the server extension automatically. Otherwise, just disable it manually.

--- a/SwanDask/jupyter-config/jupyter_notebook_config.d/dask_labextension.json
+++ b/SwanDask/jupyter-config/jupyter_notebook_config.d/dask_labextension.json
@@ -1,0 +1,7 @@
+{
+  "NotebookApp": {
+    "nbserver_extensions": {
+      "dask_labextension": false
+    }
+  }
+}

--- a/SwanDask/jupyter-config/jupyter_server_config.d/dask_labextension.json
+++ b/SwanDask/jupyter-config/jupyter_server_config.d/dask_labextension.json
@@ -1,0 +1,7 @@
+{
+  "ServerApp": {
+    "jpserver_extensions": {
+      "dask_labextension": false
+    }
+  }
+}

--- a/SwanDask/pyproject.toml
+++ b/SwanDask/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["jupyter_packaging~=0.4.0", "setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/SwanDask/setup.py
+++ b/SwanDask/setup.py
@@ -1,0 +1,59 @@
+import os
+
+import setuptools
+from jupyter_packaging import get_version
+
+name = "swandask"
+
+# Get our version
+version = get_version(os.path.join(name, "_version.py"))
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setup_args = dict(
+    name=name,
+    version=version,
+    url="https://github.com/swan-cern/jupyter-extensions",
+    author="SWAN Admins",
+    description="Wrapper to run dask_jupyterlab as an external process",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    data_files=[
+        (
+            "etc/jupyter/jupyter_server_config.d",
+            ["jupyter-config/jupyter_server_config.d/dask_labextension.json"],
+        ),
+        (
+            "etc/jupyter/jupyter_notebook_config.d",
+            ["jupyter-config/jupyter_notebook_config.d/dask_labextension.json"],
+        ),
+    ],
+    packages=setuptools.find_packages(),
+    install_requires=["dask_labextension", "jupyter-server-proxy", "tornado"],
+    zip_safe=False,
+    include_package_data=True,
+    license="AGPL-3.0",
+    platforms="Linux, Mac OS X",
+    keywords=["JupyterLab", "SWAN", "CERN"],
+    entry_points={
+        "console_scripts": [
+            "swandask = swandask.app:main",
+        ],
+        "jupyter_serverproxy_servers": [
+            "dask = swandask:setup_proxy",
+        ],
+    },
+    classifiers=[
+        "License :: OSI Approved :: GNU Affero General Public License v3",
+        "Intended Audience :: Developers",
+        "Intended Audience :: System Administrators",
+        "Intended Audience :: Science/Research",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+    ],
+)
+
+
+if __name__ == "__main__":
+    setuptools.setup(**setup_args)

--- a/SwanDask/swandask/__init__.py
+++ b/SwanDask/swandask/__init__.py
@@ -1,0 +1,23 @@
+from jupyter_client.kernelspec import get_kernel_spec
+
+from ._version import __version__
+
+
+def get_env():
+    env = get_kernel_spec("python3").env
+    # jupyter-proxy-server will try to format the env strings, which might fail
+    # i.e, we have '"EOS_PATH_FORMAT": "/eos/user/{username[0]}/{username}/"', which fails
+    # looking for 'username'
+    for key in env:
+        env[key] = env[key].replace("{", "{{").replace("}", "}}")
+
+    return env
+
+
+def setup_proxy():
+    return {
+        "command": ["swandask", "--port", "{port}", "--base_url", "{base_url}"],
+        "absolute_url": True,
+        "launcher_entry": {"enabled": False},
+        "environment": get_env,
+    }

--- a/SwanDask/swandask/__main__.py
+++ b/SwanDask/swandask/__main__.py
@@ -1,0 +1,4 @@
+from .app import main
+
+if __name__ == "__main__":
+    main()

--- a/SwanDask/swandask/_version.py
+++ b/SwanDask/swandask/_version.py
@@ -1,0 +1,3 @@
+# please don't modify this file,
+# this is automatically updated by bump2version
+__version__ = "0.0.0"

--- a/SwanDask/swandask/app.py
+++ b/SwanDask/swandask/app.py
@@ -1,0 +1,32 @@
+import argparse
+import logging
+
+from dask_labextension import load_jupyter_server_extension
+from tornado import ioloop, web
+
+
+class WebApp:
+    pass
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", default=9191, type=int, action="store", dest="port")
+    parser.add_argument("--base_url", default="/", action="store", dest="base_url")
+    args = parser.parse_args()
+
+    log = logging.getLogger("tornado.swandask")
+    log.name = "SwanDask"
+    log.setLevel(logging.INFO)
+    log.propagate = True
+    log.info(f"Running SwanDask on port {args.port} with base url {args.base_url}")
+
+    # If no remote access allowed, Jupyter will check if we're serving from https://localhost
+    app = web.Application(base_url=args.base_url, allow_remote_access=True)
+
+    server_app = WebApp()
+    server_app.web_app = app
+    load_jupyter_server_extension(server_app)
+
+    app.listen(args.port)
+    ioloop.IOLoop.current().start()


### PR DESCRIPTION
This simple wrapper allows us to run Dask not as a server extension, but as a separate process where we can configure the environment. I don't think we can get simpler, and less maintenance free, than this.

For now, the environment is taken from the python3 kernel (this could be configurable at some point). 
**I haven't tested it with the LCG stack, so we might need to fix some details** (add some local path in the env, if we serve the dask extension locally, or maybe change the way we call the process, since the current approach will probably use the local python binary instead of the lcg). But these are very minor issues.

This extension requires a to-be-released version of `jupyter-server-proxy`. The latest doesn't allow empty bodies on PUT requests, which the Dask extension does when creating a cluster. This is already fixed in master, so it's a matter of waiting for a new release or compile it.

@etejedor can you test and check the details I've mentioned?