### PR TITLE
Separate PortAllocator from SparkConnector

### DIFF
--- a/SparkConnector/setup.py
+++ b/SparkConnector/setup.py
@@ -36,10 +36,6 @@ package_data_spec = {
 
 data_files_spec = [
     ("share/jupyter/labextensions/@swan-cern/sparkconnector", lab_path, "**"),
-    ("etc/jupyter/jupyter_server_config.d",
-     "jupyter-config/jupyter_server_config.d", "sparkconnector.json"),
-     ("etc/jupyter/jupyter_notebook_config.d",
-     "jupyter-config/jupyter_notebook_config.d", "sparkconnector.json"),
 ]
 
 cmdclass = create_cmdclass("jsdeps", 
@@ -69,6 +65,7 @@ setup_args = dict(
     install_requires=[
         "jupyterlab~=3.0",
         "bs4",
+        "swanportallocator",
     ],
     zip_safe=False,
     include_package_data=True,

--- a/SparkConnector/sparkconnector/__init__.py
+++ b/SparkConnector/sparkconnector/__init__.py
@@ -1,11 +1,5 @@
 from ._version import __version__ 
 
-def _jupyter_server_extension_paths():
-    """ Used by "jupyter serverextension" command to install web server extension """
-    return [{
-        "module": "sparkconnector.portallocator"
-    }]
-
 def _jupyter_nbextension_paths():
     """ Used by "jupyter nbextension" command to install frontend extension """
     return [dict(

--- a/SparkConnector/sparkconnector/connector.py
+++ b/SparkConnector/sparkconnector/connector.py
@@ -8,7 +8,8 @@ import os, logging, tempfile, subprocess
 from pyspark import SparkContext
 from pyspark.sql import SparkSession
 
-from .portallocator import PortsAllocatorClient, NoPortsException, GeneralException
+from swanportallocator.portallocator import PortAllocatorClient, NoPortsException, GeneralException
+
 from .configuration import SparkConfigurationFactory
 from .logreader import LogReader
 
@@ -25,7 +26,7 @@ class SparkConnector:
         log_path = self.file_thread.create_file()
         self.log4j_file = self.create_properties_file(log_path)
         self.file_thread.start()
-        self.port_allocator = PortsAllocatorClient()
+        self.port_allocator = PortAllocatorClient()
         self.spark_configuration = SparkConfigurationFactory(connector=self).create()
 
     def send(self, msg):

--- a/SwanPortAllocator/.bumpversion.cfg
+++ b/SwanPortAllocator/.bumpversion.cfg
@@ -1,0 +1,8 @@
+[bumpversion]
+current_version = 0.0.0
+commit = True
+tag = True
+tag_name = SwanPortAllocator/v{new_version}
+message = SwanPortAllocator v{new_version}
+
+[bumpversion:file:swanportallocator/_version.py]

--- a/SwanPortAllocator/MANIFEST.in
+++ b/SwanPortAllocator/MANIFEST.in
@@ -1,0 +1,10 @@
+include LICENSE
+include README.md
+include pyproject.toml
+
+# Patterns to exclude from any directory
+global-exclude *~
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude .git
+global-exclude .ipynb_checkpoints

--- a/SwanPortAllocator/README.md
+++ b/SwanPortAllocator/README.md
@@ -1,0 +1,23 @@
+# SwanPortAllocator
+
+Extension that provides a port allocation mechanism to other SWAN components.
+
+## Requirements
+
+* pyzmq
+
+## Install
+
+```bash
+pip install swanportallocator
+```
+
+## Usage
+
+Configure the server extension to load when the notebook server starts
+
+```bash
+ jupyter serverextension enable --py --user swanportallocator
+```
+
+Class `swanportallocator.portallocator.PortAllocatorClient` can be used to connect to the port allocator process and get a given number of free ports.

--- a/SwanPortAllocator/jupyter-config/jupyter_notebook_config.d/swanportallocator.json
+++ b/SwanPortAllocator/jupyter-config/jupyter_notebook_config.d/swanportallocator.json
@@ -1,7 +1,7 @@
 {
     "NotebookApp": {
         "nbserver_extensions": {
-            "sparkconnector.portallocator": true
+            "swanportallocator.portallocator": true
         }
     }
 }

--- a/SwanPortAllocator/jupyter-config/jupyter_server_config.d/swanportallocator.json
+++ b/SwanPortAllocator/jupyter-config/jupyter_server_config.d/swanportallocator.json
@@ -1,7 +1,7 @@
 {
     "ServerApp": {
         "jpserver_extensions": {
-            "sparkconnector.portallocator": true
+            "swanportallocator.portallocator": true
         }
     }
 }

--- a/SwanPortAllocator/pyproject.toml
+++ b/SwanPortAllocator/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["jupyter_packaging~=0.4.0", "jupyterlab~=3.0", "setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/SwanPortAllocator/setup.py
+++ b/SwanPortAllocator/setup.py
@@ -1,0 +1,57 @@
+"""
+Setup Module to setup Python Handlers for the SwanPortAllocator extension.
+"""
+import os
+
+from jupyter_packaging import get_version
+import setuptools
+
+name="swanportallocator"
+
+# Get our version
+version = get_version(os.path.join(name, "_version.py"))
+
+data_files_spec = [
+    ("etc/jupyter/jupyter_server_config.d",
+     "jupyter-config/jupyter_server_config.d", "swanportallocator.json"),
+    ("etc/jupyter/jupyter_notebook_config.d",
+     "jupyter-config/jupyter_notebook_config.d", "swanportallocator.json"),
+]
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setup_args = dict(
+    name=name,
+    version=version,
+    url="https://github.com/swan-cern/jupyter-extensions",
+    author="SWAN Admins",
+    description="Extension that provides a port allocation mechanism to other SWAN components",
+    long_description= long_description,
+    long_description_content_type="text/markdown",
+    packages=setuptools.find_packages(),
+    install_requires=[
+        'pyzmq',
+    ],
+    zip_safe=False,
+    include_package_data=True,
+    python_requires=">=3.6",
+    license="AGPL-3.0",
+    platforms="Linux, Mac OS X, Windows",
+    keywords=["Jupyter", "Notebooks", "SWAN", "CERN"],
+    classifiers=[
+        "License :: OSI Approved :: GNU Affero General Public License v3",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Framework :: Jupyter",
+    ],
+)
+
+
+if __name__ == "__main__":
+    setuptools.setup(**setup_args)

--- a/SwanPortAllocator/swanportallocator/__init__.py
+++ b/SwanPortAllocator/swanportallocator/__init__.py
@@ -1,0 +1,11 @@
+from ._version import __version__
+
+def _jupyter_nbextension_paths():
+    # Empty to avoid error when automatically trying to enable all nbextensions
+    return []
+
+def _jupyter_server_extension_paths():
+    """Used by "jupyter serverextension" command to install web server extension'"""
+    return [{
+        "module": "swanportallocator.portallocator"
+    }]

--- a/SwanPortAllocator/swanportallocator/_version.py
+++ b/SwanPortAllocator/swanportallocator/_version.py
@@ -1,0 +1,3 @@
+# please don't modify this file,
+# this is automatically updated by bump2version
+__version__ = '0.0.0'

--- a/SwanPortAllocator/swanportallocator/portallocator.py
+++ b/SwanPortAllocator/swanportallocator/portallocator.py
@@ -31,7 +31,7 @@ class Actions(Enum):
     SET_STATUS = "set_status"
 
 
-class PortsAllocator(threading.Thread):
+class PortAllocator(threading.Thread):
     """
         Master service that manages all the ports allocated to the session.
         Keeps track of which processes are using them and manages the lifecycle of the ports, in order to
@@ -47,7 +47,7 @@ class PortsAllocator(threading.Thread):
         """
         self.ports_available = os.environ.get("SPARK_PORTS", "").split(',')
         self.clients = {}
-        self.queue_port = PortsAllocator.get_reserved_port()
+        self.queue_port = PortAllocator.get_reserved_port()
         self.log = log
 
         # Store the queue port so that the clients know where to connect
@@ -223,9 +223,9 @@ class PortsAllocator(threading.Thread):
                 pass
 
 
-class PortsAllocatorClient:
+class PortAllocatorClient:
     """
-       Proxy to the Ports Allocator process, using a message queue.
+       Proxy to the Port Allocator process, using a message queue.
        It asks for a number of ports to be allocated to this specific process.
        Port Allocator checks if the ports are in use and, if not, it might give them to
        other processes.
@@ -311,13 +311,13 @@ def load_jupyter_server_extension(nb_server_app):
         nb_server_app (NotebookWebApplication): handle to the Notebook webserver instance.
     """
 
-    log = logging.getLogger('tornado.sparkconnector.portsallocator')
-    log.name = "SparkConnector.PortsAllocator"
+    log = logging.getLogger('tornado.swanportallocator')
+    log.name = "SwanPortAllocator"
     log.setLevel(logging.INFO)
     log.propagate = True
 
     log.info("Loading Server Extension")
 
-    thread = PortsAllocator(log)
+    thread = PortAllocator(log)
     thread.setDaemon(True)
     thread.start()


### PR DESCRIPTION
Even though `SparkConnector` is the only SWAN component that needs to allocate ports at the moment, the future support for Dask HTCondor and its need for port allocation motivates the separation of `PortAllocator` in its own extension, which will centrally manage ports for any SWAN component that needs them.