### PR TITLE
Fix CI for SparkConnector

### DIFF
--- a/SparkConnector/MANIFEST.in
+++ b/SparkConnector/MANIFEST.in
@@ -2,15 +2,16 @@ include LICENSE
 include README.md
 include pyproject.toml
 
-graft jupyter-config
 
 include package.json
 include ts*.json
+include yarn.lock
 graft sparkconnector/labextension
 include sparkconnector/nbextension/*.js
 
 # Javascript files
 graft src
+graft nbextension
 graft style
 prune **/node_modules
 prune lib


### PR DESCRIPTION
add yarn.lock to MANIFEST.in so that `python -m build` from an isolated venv works.