### PR TITLE
[SPARK-8] fix broken links and update descriptions in the window "Spark clusters connection

### DIFF
--- a/SparkConnector/nbextension/src/extension.js
+++ b/SparkConnector/nbextension/src/extension.js
@@ -1003,14 +1003,14 @@ SparkConnector.prototype.get_html_connected = function (config, error) {
     if (config && config.sparkmetrics) {
         var metricsURL = $('<a>').attr('href', config.sparkmetrics).attr('target','_blank').text('here')
         html.find('.success-metrics-text')
-            .text('Spark Metrics are available ')
+            .text('Spark Metrics Dashboard is available ')
             .append(metricsURL)
     }
 
     if (config && config.sparkhistoryserver) {
         var historyserverURL = $('<a>').attr('href', config.sparkhistoryserver).attr('target','_blank').text('here')
         html.find('.success-history-text')
-            .text('Spark History Server is available ')
+            .text('Spark WebUI - History Server is available ')
             .append(historyserverURL)
     }
 

--- a/SparkConnector/nbextension/src/templates/connected.html
+++ b/SparkConnector/nbextension/src/templates/connected.html
@@ -1,17 +1,17 @@
 <p class="success"><i class="icon-checked"></i>You are connected to <b>{cluster_name}</b></p>
 <p><b>The following variables were instantiated</b></p>
 <ul class="variables">
-    <li>sc = <a href="https://spark.apache.org/docs/latest/api/python/pyspark.html#pyspark.SparkContext"
+    <li>sc = <a href="https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.SparkContext.html"
                        target="_blank">SparkContext</a></li>
     <li>spark = <a
-            href="https://spark.apache.org/docs/latest/api/python/pyspark.sql.html#pyspark.sql.SparkSession"
+            href="https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.SparkSession.html"
             target="_blank">SparkSession</a></li>
 </ul>
 <p><b>Connection details</b></p>
 <ul class="variables">
     <li>Spark version is {spark_version}</li>
-    <li class="success-history-text">Spark History is not available</li>
-    <li class="success-metrics-text">Spark Metrics are not available (requires enabled bundle)</li>
+    <li class="success-history-text">Spark WebUI is not available</li>
+    <li class="success-metrics-text">Spark Metrics Dashboard is not activated (see config bundles)</li>
     <li>Spark driver logs of the running application <a class="success-show-logs-action"></a></li>
 </ul>
 <div class="log-connected">

--- a/SparkConnector/src/components/connected.tsx
+++ b/SparkConnector/src/components/connected.tsx
@@ -28,7 +28,7 @@ const YouAreConnecedTo = observer(() => {
       <li>
         sc:{' '}
         <a
-          href="https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.SparkContext.html#pyspark.SparkContext"
+          href="https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.SparkContext.html"
           target="_blank"
           rel="noreferrer"
         >
@@ -40,7 +40,7 @@ const YouAreConnecedTo = observer(() => {
       <li>
         spark:{' '}
         <a
-          href="https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.SparkSession.html#pyspark.sql.SparkSession"
+          href="https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.SparkSession.html"
           target="_blank"
           rel="noreferrer"
         >


### PR DESCRIPTION
Fix broken links to spark context and spark session description + propose minor change to the description of the WebUI and Spark Metrics Dashboard links