### PR TITLE
Update node version installed by the CI

### DIFF
--- a/.github/workflows/swan-ci-ca.yml
+++ b/.github/workflows/swan-ci-ca.yml
@@ -49,7 +49,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         always-auth: true
-        node-version: '12.x'
+        node-version: '19.x'
         registry-url: https://registry.npmjs.org
 
     - name: Install dependencies 


### PR DESCRIPTION
This is needed since the merge of the JupyterLab SWAN gallery into SwanHelp. Otherwise the latter does not build.