### PR TITLE
Use the WebUI for Spark on YARN instead of using Spark history server.

### DIFF
--- a/SparkConnector/nbextension/src/extension.js
+++ b/SparkConnector/nbextension/src/extension.js
@@ -1010,7 +1010,7 @@ SparkConnector.prototype.get_html_connected = function (config, error) {
     if (config && config.sparkhistoryserver) {
         var historyserverURL = $('<a>').attr('href', config.sparkhistoryserver).attr('target','_blank').text('here')
         html.find('.success-history-text')
-            .text('Spark WebUI: History Server is available ')
+            .text('Spark WebUI is available ')
             .append(historyserverURL)
     }
 

--- a/SparkConnector/nbextension/src/extension.js
+++ b/SparkConnector/nbextension/src/extension.js
@@ -1007,11 +1007,11 @@ SparkConnector.prototype.get_html_connected = function (config, error) {
             .append(metricsURL)
     }
 
-    if (config && config.sparkhistoryserver) {
-        var historyserverURL = $('<a>').attr('href', config.sparkhistoryserver).attr('target','_blank').text('here')
+    if (config && config.sparkwebui) {
+        var webuiURL = $('<a>').attr('href', config.sparkwebui).attr('target','_blank').text('here')
         html.find('.success-history-text')
             .text('Spark WebUI is available ')
-            .append(historyserverURL)
+            .append(webuiURL)
     }
 
     html.find('.success-show-logs-action')

--- a/SparkConnector/sparkconnector/configuration.py
+++ b/SparkConnector/sparkconnector/configuration.py
@@ -399,15 +399,12 @@ class SparkYarnConfiguration(SparkConfiguration):
                                               '&var-UserName=' + self.get_spark_user() + \
                                               '&var-ApplicationId=' + app_id
 
-            # determine the history server URL depending on the selected resource manager (yarn, k8s, local etc)
-            historyserver_url = self._get_sc_config(
-                'spark.yarn.historyServer.address',
+            # determine the WebUI URL for Spark on YARN
+            webui_urls = self._get_sc_config(
+                'spark.org.apache.hadoop.yarn.server.webproxy.amfilter.AmIpFilter.param.PROXY_URI_BASES',
                 wait=True
             )
-            historyserver_protocol = 'https' if self._get_sc_config('spark.ssl.historyServer.enabled') else 'http'
-
-            ui_url = f'{historyserver_protocol}://{historyserver_url}/history/{app_id}'
-            if ui_url:
-                conn_config['sparkhistoryserver'] = ui_url
+            if webui_urls:
+                conn_config['sparkhistoryserver'] = webui_urls.split(',', 1)[0]
 
         return conn_config

--- a/SparkConnector/sparkconnector/configuration.py
+++ b/SparkConnector/sparkconnector/configuration.py
@@ -399,7 +399,13 @@ class SparkYarnConfiguration(SparkConfiguration):
                                               '&var-UserName=' + self.get_spark_user() + \
                                               '&var-ApplicationId=' + app_id
 
-            # determine the WebUI URL for Spark on YARN
+            # Determine the WebUI URL for Spark on YARN
+            # First, we get a list of 2 potential proxy addresses,
+            # one for each YARN RM (we have 2 Resource Managers in our Hadoop configs)
+            # Example result:
+            # 'https://ithdpXXX1.cern.ch:8088/proxy/application_1688370955275_70252,
+            # https://ithdpXXX2.cern.ch:8088/proxy/application_1688370955275_70252'
+            # Then we simply take the first one and use it as the WebUi URL
             webui_urls = self._get_sc_config(
                 'spark.org.apache.hadoop.yarn.server.webproxy.amfilter.AmIpFilter.param.PROXY_URI_BASES',
                 wait=True

--- a/SparkConnector/sparkconnector/configuration.py
+++ b/SparkConnector/sparkconnector/configuration.py
@@ -176,8 +176,8 @@ class SparkLocalConfiguration(SparkConfiguration):
 
         sc = self.connector.ipython.user_ns.get('sc')
         if sc and isinstance(sc, SparkContext):
-            history_url = 'http://' + sc._conf.get('spark.driver.host') + ':' + sc._conf.get('spark.ui.port')
-            conn_config['sparkhistoryserver'] = history_url
+            webui_url = 'http://' + sc._conf.get('spark.driver.host') + ':' + sc._conf.get('spark.ui.port')
+            conn_config['sparkwebui'] = webui_url
         return conn_config
 
 
@@ -334,8 +334,8 @@ class SparkK8sConfiguration(SparkConfiguration):
                                               '&var-UserName=' + self.get_spark_user() + \
                                               '&var-ApplicationId=' + sc._conf.get('spark.app.id')
 
-            history_url = 'http://' + sc._conf.get('spark.driver.host') + ':' + sc._conf.get('spark.ui.port')
-            conn_config['sparkhistoryserver'] = history_url
+            webui_url = 'http://' + sc._conf.get('spark.driver.host') + ':' + sc._conf.get('spark.ui.port')
+            conn_config['sparkwebui'] = webui_url
 
         return conn_config
 
@@ -411,6 +411,6 @@ class SparkYarnConfiguration(SparkConfiguration):
                 wait=True
             )
             if webui_urls:
-                conn_config['sparkhistoryserver'] = webui_urls.split(',', 1)[0]
+                conn_config['sparkwebui'] = webui_urls.split(',', 1)[0]
 
         return conn_config

--- a/SparkConnector/src/components/connected.tsx
+++ b/SparkConnector/src/components/connected.tsx
@@ -64,7 +64,7 @@ export const Connected = observer(() => {
             component="a"
             target="_blank"
             href={
-              store.currentNotebook?.connectionResources?.sparkHistoryServerUrl
+              store.currentNotebook?.connectionResources?.sparkWebuiUrl
             }
           >
             <ListItemIcon>

--- a/SparkConnector/src/labconnector.ts
+++ b/SparkConnector/src/labconnector.ts
@@ -184,7 +184,7 @@ export class JupyterLabConnector {
         }
         case 'sparkconn-connected': {
           store.notebooks[notebookPanel.id].connectionResources = {
-            sparkHistoryServerUrl: data.config.sparkhistoryserver as string,
+            sparkWebuiUrl: data.config.sparkwebui as string,
             sparkMetricsUrl: data.config.sparkmetrics as string,
           };
           store.notebooks[notebookPanel.id].status = 'connected';

--- a/SparkConnector/src/store.ts
+++ b/SparkConnector/src/store.ts
@@ -208,7 +208,7 @@ class NotebookStateStore {
   selectedBundles: Array<string> = [];
   errorMessage?: string;
   connectionResources?: {
-    sparkHistoryServerUrl?: string;
+    sparkWebuiUrl?: string;
     sparkMetricsUrl?: string;
     logs?: string[];
   };


### PR DESCRIPTION
The use of the Spark history server was a workaround introduced for SWAN on k8s, this appears not to be necessary any more, the WebUI should be preferred as it has more functionality.