### PR TITLE
Refactor git clone for git projects on SWAN

### DIFF
--- a/SwanContents/swancontents/filemanager/swanfilemanager.py
+++ b/SwanContents/swancontents/filemanager/swanfilemanager.py
@@ -382,7 +382,7 @@ class SwanFileManager(SwanFileManagerMixin, LargeFileManager):
 
         if url.endswith('.git'):
 
-            rc = subprocess.run(['git', 'clone', '--recurse-submodules', url, tmp_dir_name])
+            rc = subprocess.run(['git', 'clone', '--recurse-submodules', '--', url, tmp_dir_name])
             if rc.returncode != 0:
                 raise web.HTTPError(400, "It was not possible to clone the repo %s. Did you pass the username/token?" % url)
 

--- a/SwanContents/swancontents/filemanager/swanfilemanager.py
+++ b/SwanContents/swancontents/filemanager/swanfilemanager.py
@@ -381,8 +381,10 @@ class SwanFileManager(SwanFileManagerMixin, LargeFileManager):
         tmp_dir_name = tempfile.mkdtemp()
 
         if url.endswith('.git'):
-
-            rc = subprocess.run(['git', 'clone', '--recurse-submodules', '--', url, tmp_dir_name])
+            # Use subprocess.run instead of subprocess.call as the later one is deprecated and add the "--"
+            # to separate the process arguments from the url, to prevent users from passing command options
+            # in the place of the url.
+            rc = subprocess.run(['git', 'clone', '--recurse-submodules', '--depth=1', '--', url, tmp_dir_name])
             if rc.returncode != 0:
                 raise web.HTTPError(400, "It was not possible to clone the repo %s. Did you pass the username/token?" % url)
 

--- a/SwanContents/swancontents/filemanager/swanfilemanager.py
+++ b/SwanContents/swancontents/filemanager/swanfilemanager.py
@@ -382,8 +382,8 @@ class SwanFileManager(SwanFileManagerMixin, LargeFileManager):
 
         if url.endswith('.git'):
 
-            rc = subprocess.call(['git', 'clone', '--recurse-submodules', url, tmp_dir_name])
-            if rc != 0:
+            rc = subprocess.run(['git', 'clone', '--recurse-submodules', url, tmp_dir_name])
+            if rc.returncode != 0:
                 raise web.HTTPError(400, "It was not possible to clone the repo %s. Did you pass the username/token?" % url)
 
             dest_dir_name_ext = os.path.basename(url)

--- a/SwanContents/swancontents/filemanager/swanfilemanager.py
+++ b/SwanContents/swancontents/filemanager/swanfilemanager.py
@@ -382,12 +382,9 @@ class SwanFileManager(SwanFileManagerMixin, LargeFileManager):
 
         if url.endswith('.git'):
 
-            rc = subprocess.call(['git', 'clone', url, tmp_dir_name])
+            rc = subprocess.call(['git', 'clone', '--recurse-submodules', url, tmp_dir_name])
             if rc != 0:
                 raise web.HTTPError(400, "It was not possible to clone the repo %s. Did you pass the username/token?" % url)
-
-            # Also download submodules if they exist
-            subprocess.call(['git', 'submodule', 'update', '--init', '--recursive'], cwd=tmp_dir_name)
 
             dest_dir_name_ext = os.path.basename(url)
             repo_name_no_ext = os.path.splitext(dest_dir_name_ext)[0]


### PR DESCRIPTION
Set a 2 minutes timeout when cloning git repositories through the SWAN file manager.

Furthermore, added a double dash to the git clone process, to prevent security issues (users can pass command options in the place of the url currently).