### PR TITLE
orgId should not be hardcoded for the spark metrics dashboard

### DIFF
--- a/SparkConnector/sparkconnector/configuration.py
+++ b/SparkConnector/sparkconnector/configuration.py
@@ -329,7 +329,6 @@ class SparkK8sConfiguration(SparkConfiguration):
             if sc._conf.get('spark.cern.grafana.url') is not None:
                 # if spark.cern.grafana.url is set, use cern spark monitoring dashboard
                 conn_config['sparkmetrics'] = sc._conf.get('spark.cern.grafana.url') + \
-                                              '?orgId=1' + \
                                               '&var-ClusterName=' + self.get_cluster_name() + \
                                               '&var-UserName=' + self.get_spark_user() + \
                                               '&var-ApplicationId=' + sc._conf.get('spark.app.id')


### PR DESCRIPTION
orgId should not be hardcoded for the spark metrics dashboard. The  goes together with an update of the parameters bundle used to migrate the dashboard to a new location.