### PR TITLE
Make portallocator generic to also handle requests from the Dask lab extension

### DIFF
--- a/SwanPortAllocator/swanportallocator/portallocator.py
+++ b/SwanPortAllocator/swanportallocator/portallocator.py
@@ -205,7 +205,7 @@ class PortAllocator(threading.Thread):
                 }
                 zmq_socket.send_json(msg)
 
-            def send_ok(content):
+            def send_ok(content = None):
                 send_msg('ok', content)
 
             def send_error(content):
@@ -227,11 +227,11 @@ class PortAllocator(threading.Thread):
 
                         elif message['action'] == Actions.RELEASE_PORT.value:
                             self.release_ports(message['process'], message['ports'])
-                            send_ok(message['ports'])
+                            send_ok()
 
                         elif message['action'] == Actions.SET_STATUS.value:
                             self.set_status(message['process'], message['status'])
-                            send_ok(message['status'])
+                            send_ok()
 
                     except NoPortsException:
                         send_error(Errors.NO_PORTS_AVAILABLE.value)

--- a/SwanPortAllocator/swanportallocator/portallocator.py
+++ b/SwanPortAllocator/swanportallocator/portallocator.py
@@ -40,15 +40,15 @@ class PortAllocator(threading.Thread):
 
     def __init__(self, log):
         """
-            Creates a list of available ports in the session, by reading the SPARK_PORTS env variable,
+            Creates a list of available ports in the session, by reading the COMPUTING_PORTS env variable,
             that should contain a comma separated list of ports.
             Starts a communication queue in one available internal port, and then listens for incoming
             requests.
         """
         self.ports_available = []
-        spark_ports = os.environ.get('SPARK_PORTS')
-        if spark_ports is not None:
-            self.ports_available += spark_ports.split(',')
+        ports = os.environ.get('COMPUTING_PORTS')
+        if ports is not None:
+            self.ports_available += ports.split(',')
         self.clients = {}
         self.queue_port = PortAllocator.get_reserved_port()
         self.log = log


### PR DESCRIPTION
This changes the port allocator to:
- Handle a variable with generic computing ports, which can be requested by either the Spark connector or the Dask lab extension.
- If a process already asked for ports, do not return the same ports if the same process asks again -- this is important for the Dask lab extension to work, because on every creation of a SwanHTCondorCluster, a new port will be requested by the same process
- Be able to release ports (when a SwanHTCondorCluster is shut down, its corresponding port is released).