### PR TITLE
Fix swancontents

### DIFF
--- a/SwanContents/MANIFEST.in
+++ b/SwanContents/MANIFEST.in
@@ -4,8 +4,9 @@ include pyproject.toml
 
 include jupyter-config/swancontents.json
 
-graft swancontents/js
-graft swancontents/templates/
+graft swancontents/swanclassic/static
+graft swancontents/swanclassic/templates
+graft swancontents/serverextension/templates
 
 # Patterns to exclude from any directory
 global-exclude *~

--- a/SwanContents/swancontents/__init__.py
+++ b/SwanContents/swancontents/__init__.py
@@ -1,7 +1,7 @@
 from ._version import __version__
 
 
-def _jupyter_server_extension_paths():
+def _jupyter_server_extension_points():
     from .swanclassic.notebookapp import NotebookApp
 
     return [


### PR DESCRIPTION
By mistake I forgot to change the api endpoint, so there were some warning about future deprecation.

The wheel was also missing the static files.

I'll also add a Lab extension to allow users to switch between interfaces (lab/old), just like what happens when Lab is installed with the new Notebook (v7) and Nbclassic.