### PR TITLE
Make sure SwanDask runs with the LCG python

### DIFF
--- a/SwanDask/swandask/__init__.py
+++ b/SwanDask/swandask/__init__.py
@@ -15,8 +15,10 @@ def get_env():
 
 
 def setup_proxy():
+    # SwanDask needs to run with the LCG python
+    python_bin = get_kernel_spec("python3").argv[0]
     return {
-        "command": ["swandask", "--port", "{port}", "--base_url", "{base_url}"],
+        "command": [python_bin, "-m", "swandask", "--port", "{port}", "--base_url", "{base_url}"],
         "absolute_url": True,
         "timeout": 10,
         "launcher_entry": {"enabled": False},


### PR DESCRIPTION
SwanDask (and Dask lab extension) make use of libraries that are present in the LCG release (e.g. Dask), that is why we configure the SwanDask environment with the LCG release. In addition, here we make sure the Python of the LCG release is used, and not the one installed in the base user image, since this can cause compatibility problems.