### PR TITLE
Adapt to new naming host_allowlist in jupyter_server_proxy

### DIFF
--- a/SwanDask/swandask/app.py
+++ b/SwanDask/swandask/app.py
@@ -24,7 +24,7 @@ def _set_dashboard_whitelist():
 
     def custom_init(self, *args, **kwargs):
         super(DaskDashboardHandler, self).__init__(*args,
-                                                   host_whitelist=[private_ip],
+                                                   host_allowlist=[private_ip],
                                                    *kwargs)
 
     DaskDashboardHandler.__init__ = partialmethod(custom_init)


### PR DESCRIPTION
Since jupyter_server_proxy 3.0.0, host_whitelist is replaced by host_allowlist:
https://jupyter-server-proxy.readthedocs.io/en/latest/changelog.html#id46