### PR TITLE
Configure spark.kubernetes.container.image depending on the Linux distribution

### DIFF
--- a/SparkConnector/sparkconnector/configuration.py
+++ b/SparkConnector/sparkconnector/configuration.py
@@ -269,11 +269,6 @@ class SparkK8sConfiguration(SparkConfiguration):
         conf.set('spark.kubernetes.namespace', os.environ.get('SPARK_USER'))
         conf.set('spark.master', self._retrieve_k8s_master(os.environ.get('KUBECONFIG')))
 
-        # Configure shuffle if running on K8s with Spark 3.x.x
-        if self.get_spark_version().split('.')[0]=='3':
-            conf.set('spark.shuffle.service.enabled', 'false')
-            conf.set('spark.dynamicAllocation.shuffleTracking.enabled', 'true')
-
         # Ensure that Spark ENVs on executors are the same as on the driver
         conf.set('spark.executorEnv.PYTHONPATH', os.environ.get('PYTHONPATH'))
         conf.set('spark.executorEnv.JAVA_HOME', os.environ.get('JAVA_HOME'))

--- a/SparkConnector/sparkconnector/configuration.py
+++ b/SparkConnector/sparkconnector/configuration.py
@@ -272,8 +272,7 @@ class SparkK8sConfiguration(SparkConfiguration):
         # The image used by the Spark executor should be set by the spawner, as we need
         # different images for different platform types
         # Get the value of 'SPARK_K8S_EXECUTOR_CONTAINER_IMAGE_URL' environment variable
-        # The default value is a stopgap till we implement the changes in the spawner
-        container_image_url = os.environ.get('SPARK_K8S_EXECUTOR_CONTAINER_IMAGE_URL',
+        container_image_url = os.environ.get('SPARK_EXECUTOR_IMAGE',
                               'gitlab-registry.cern.ch/db/spark-service/docker-registry/swan:cc7-20240123')
         # Set the configuration using the obtained or default value
         conf.set('spark.kubernetes.container.image', container_image_url)

--- a/SparkConnector/sparkconnector/configuration.py
+++ b/SparkConnector/sparkconnector/configuration.py
@@ -269,6 +269,15 @@ class SparkK8sConfiguration(SparkConfiguration):
         conf.set('spark.kubernetes.namespace', os.environ.get('SPARK_USER'))
         conf.set('spark.master', self._retrieve_k8s_master(os.environ.get('KUBECONFIG')))
 
+        # The image used by the Spark executor should be set by the spawner, as we need
+        # different images for different platform types
+        # Get the value of 'SPARK_K8S_EXECUTOR_CONTAINER_IMAGE_URL' environment variable
+        # The default value is a stopgap till we implement the changes in the spawner
+        container_image_url = os.environ.get('SPARK_K8S_EXECUTOR_CONTAINER_IMAGE_URL',
+                              'gitlab-registry.cern.ch/db/spark-service/docker-registry/swan:cc7-20240123')
+        # Set the configuration using the obtained or default value
+        conf.set('spark.kubernetes.container.image', container_image_url)
+
         # Ensure that Spark ENVs on executors are the same as on the driver
         conf.set('spark.executorEnv.PYTHONPATH', os.environ.get('PYTHONPATH'))
         conf.set('spark.executorEnv.JAVA_HOME', os.environ.get('JAVA_HOME'))


### PR DESCRIPTION
This is to add configuration for setting spark.kubernetes.container.image
The configuration is via an environemnt variable that can be set by the spawner.
This will allow to support executor containers built for different OSes (notably CC7 and Alma9)