### PR TITLE
orgId should not be hardcoded for the spark metrics dashboard

### DIFF
--- a/SparkConnector/sparkconnector/configuration.py
+++ b/SparkConnector/sparkconnector/configuration.py
@@ -393,7 +393,6 @@ class SparkYarnConfiguration(SparkConfiguration):
             if grafana_url and app_id:
                 # if spark.cern.grafana.url is set, use cern spark monitoring dashboard
                 conn_config['sparkmetrics'] = grafana_url + \
-                                              '?orgId=1' + \
                                               '&var-ClusterName=' + self.get_cluster_name() + \
                                               '&var-UserName=' + self.get_spark_user() + \
                                               '&var-ApplicationId=' + app_id


### PR DESCRIPTION
This follows up on https://github.com/swan-cern/jupyter-extensions/commit/31d442852eedab2cb880976673ad0bf821cbcea8 
After the move to central Grafana, orgId is now specified in the Spark Metrics bundle parameter.