### PR TITLE
SparkConnector: Set Alma9 image for Spark kubernetes executors

### DIFF
--- a/SparkConnector/sparkconnector/configuration.py
+++ b/SparkConnector/sparkconnector/configuration.py
@@ -267,6 +267,7 @@ class SparkK8sConfiguration(SparkConfiguration):
 
         # Set K8s configuration
         conf.set('spark.kubernetes.namespace', os.environ.get('SPARK_USER'))
+        conf.set('spark.kubernetes.container.image', 'gitlab-registry.cern.ch/db/spark-service/docker-registry/swan:alma9-20240123')
         conf.set('spark.master', self._retrieve_k8s_master(os.environ.get('KUBECONFIG')))
 
         # Configure shuffle if running on K8s with Spark 3.x.x


### PR DESCRIPTION
Set the Alma9 image to be used by the Spark kubernetes executors, following the migration of Spark services to this platform.

This way, the executors will choose the Alma9 image instead of the old CentOS7 one.