### PR TITLE
swancustomenvironments: New notebook args feature with new parameter

### DIFF
--- a/SwanCustomEnvironments/swancustomenvironments/scripts/makenv.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/makenv.sh
@@ -87,9 +87,6 @@ done
 REPO_GIT_PATTERN='^https?:\/\/(github\.com|gitlab\.cern\.ch)\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)\/?$'
 # EOS path pattern: $CERNBOX_HOME/<folder1>/<folder2>/...(/?) or /eos/user/<lowercase_first_letter>/<username>/<folder1>?/<folder2>?/...(/?)
 REPO_EOS_PATTERN='^(\$CERNBOX_HOME(\/[^<>|\\:()&;,\/]+)*\/?|\/eos\/user\/[a-z](\/[^<>|\\:()&;,\/]+)+\/?)$'
-# Notebook pattern: <folder1>?/<folder2>?/...?/<notebook_name>.ipynb
-REPO_NOTEBOOK_PATTERN='^([^<>|\\:()&;,\/]+\/)*[^<>|\\:()&;,\/]+\.ipynb$'
-
 
 # Checks if the provided Acc-Py version is valid
 if [ -n "$ACCPY_VERSION" ] && [ ! -e "$ACCPY_PATH/base/$ACCPY_VERSION" ]; then
@@ -200,13 +197,23 @@ fi
 _log "REPO_PATH:${REPO_PATH#$HOME}"
 
 # Checks if the provided notebook is valid and exists
+# Depending on the repository type, the root of notebook path is different
+# EOS HOME for eos repositories and the repository path for git repositories
 if [ -n "$NOTEBOOK" ]; then
-    if [[ ! "$NOTEBOOK" =~ $REPO_NOTEBOOK_PATTERN || ! -f "$CERNBOX_HOME$NOTEBOOK" ]]; then
-        _log "ERROR: Invalid notebook path (${NOTEBOOK})."
-        exit 1
-    else
-        # If a notebook is provided, redirect the user to it, otherwise to the repository path
-        _log "REPO_PATH:${NOTEBOOK}"
+    if [ "$REPO_TYPE" == "eos" ]; then
+        if [ -f "$HOME/$NOTEBOOK" ]; then
+            _log "REPO_PATH:/${NOTEBOOK}"
+        else
+            _log "WARNING: Invalid notebook path ($HOME/$NOTEBOOK)."
+            exit 1
+        fi
+    elif [ "$REPO_TYPE" == "git" ]; then
+        if [ -f "$REPO_PATH/$NOTEBOOK" ]; then
+            _log "REPO_PATH:${REPO_PATH#$HOME}/$NOTEBOOK"
+        else
+            _log "WARNING: Invalid notebook path ($REPO_PATH/$NOTEBOOK)."
+            exit 1
+        fi
     fi
 fi
 

--- a/SwanCustomEnvironments/swancustomenvironments/scripts/makenv.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/makenv.sh
@@ -83,8 +83,8 @@ done
 # --------------------------------------------------------------------------------------------
 # Validate input arguments
 
-# Git URL pattern: https://github.com/<username>/<repo_name>(/?) or https://gitlab.cern.ch/<username>/<repo_name>(/?)
-REPO_GIT_PATTERN='^https?:\/\/(github\.com|gitlab\.cern\.ch)\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)\/?$'
+# Git URL pattern: https://github.com/<username>/<repo_name>(/?) or https://gitlab.cern.ch/<username>/<repo_name>((/?)|(.git?))
+REPO_GIT_PATTERN='^https?:\/\/(github\.com|gitlab\.cern\.ch)\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)(\/|\.git)?$'
 # EOS path pattern: $CERNBOX_HOME/<folder1>/<folder2>/...(/?) or /eos/user/<lowercase_first_letter>/<username>/<folder1>?/<folder2>?/...(/?)
 REPO_EOS_PATTERN='^(\$CERNBOX_HOME(\/[^<>|\\:()&;,\/]+)*\/?|\/eos\/user\/[a-z](\/[^<>|\\:()&;,\/]+)+\/?)$'
 

--- a/SwanCustomEnvironments/swancustomenvironments/scripts/makenv.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/makenv.sh
@@ -161,17 +161,17 @@ fi
 # Create environment (acc-py or generic)
 if [ -n "$ACCPY_VERSION" ]; then
     source $ACCPY_PATH/base/${ACCPY_VERSION}/setup.sh
-    acc-py venv ${ENV_PATH}
+    acc-py venv ${ENV_PATH} | tee -a "${LOG_FILE}"
 else
     _log "Creating environment ${ENV_NAME} using Generic Python..."
-    python -m venv ${ENV_PATH}
+    python -m venv ${ENV_PATH} | tee -a "${LOG_FILE}"
 fi
 
 _log "ENV_NAME:${ENV_NAME}"
 
 # Make sure the Jupyter server finds the new environment kernel in /home/$USER/.local
 mkdir -p /home/$USER/.local/share/jupyter/kernels
-ln -f -s ${ENV_PATH}/share/jupyter/kernels/${ENV_NAME} /home/$USER/.local/share/jupyter/kernels/${ENV_NAME}
+ln -f -s ${ENV_PATH}/share/jupyter/kernels/${ENV_NAME} /home/$USER/.local/share/jupyter/kernels/${ENV_NAME} | tee -a "${LOG_FILE}"
 
 # Activate the environment
 _log "Setting up the environment..."

--- a/SwanCustomEnvironments/swancustomenvironments/serverextension.py
+++ b/SwanCustomEnvironments/swancustomenvironments/serverextension.py
@@ -22,16 +22,16 @@ class SwanCustomEnvironmentsApiHandler(APIHandler):
         """
         self.set_header("Content-Type", "text/event-stream")
 
-        repository = self.get_query_argument("repo", default=None)
-        repository_type = self.get_query_argument("repo_type", default=None)
-        accpy_version = self.get_query_argument("accpy", default=None)
+        repository = self.get_query_argument("repo", default='')
+        repository_type = self.get_query_argument("repo_type", default='')
+        accpy_version = self.get_query_argument("accpy", default='')
 
         arguments = ["--repo", repository, "--repo_type", repository_type]
-        if accpy_version is not None:
+        if accpy_version == '':
             arguments.extend(["--accpy", accpy_version])
-        
+
         makenv_process = subprocess.Popen([self.makenv_path, *arguments], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        
+
         for line in iter(makenv_process.stdout.readline, b""):
             self.write(f"data: {line.decode('utf-8')}\n\n")
             self.flush()

--- a/SwanCustomEnvironments/swancustomenvironments/serverextension.py
+++ b/SwanCustomEnvironments/swancustomenvironments/serverextension.py
@@ -19,16 +19,20 @@ class SwanCustomEnvironmentsApiHandler(APIHandler):
         Gets the arguments from the query string and runs the makenv.sh script with them.
         repo (str): The git URL or absolute unix path to the repository.
         accpy (str): The version of Accpy to be installed in the environment (optional).
+        notebook (str): The path to the notebook to be automatically opened in the environment (optional).
         """
         self.set_header("Content-Type", "text/event-stream")
 
         repository = self.get_query_argument("repo", default='')
         repository_type = self.get_query_argument("repo_type", default='')
         accpy_version = self.get_query_argument("accpy", default='')
+        notebook = self.get_query_argument("notebook", default='')
 
         arguments = ["--repo", repository, "--repo_type", repository_type]
-        if accpy_version == '':
+        if accpy_version != '':
             arguments.extend(["--accpy", accpy_version])
+        if notebook != '':
+            arguments.extend(["--notebook", notebook])
 
         makenv_process = subprocess.Popen([self.makenv_path, *arguments], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 

--- a/SwanCustomEnvironments/swancustomenvironments/templates/customenvs.html
+++ b/SwanCustomEnvironments/swancustomenvironments/templates/customenvs.html
@@ -149,6 +149,7 @@ data-base-url="{{base_url | urlencode}}"
     var repository = urlParams.get('repo') || "";
     var repository_type = urlParams.get('repo_type') || "";
     var accpy_version = urlParams.get('accpy') || "";
+    var notebook = urlParams.get('notebook') || "";
 
     // Environment creation elements
     var outputBox = document.getElementById('output-box');
@@ -164,7 +165,7 @@ data-base-url="{{base_url | urlencode}}"
     var modalJupyter = document.getElementById("modal-lab-button");
 
     // Create EventSource to listen for updates from the backend
-    var eventSource = new EventSource(`${base_url}api/customenvs?repo=${encodeURIComponent(repository)}&repo_type=${encodeURIComponent(repository_type)}&accpy=${encodeURIComponent(accpy_version)}`);
+    var eventSource = new EventSource(`${base_url}api/customenvs?repo=${encodeURIComponent(repository)}&repo_type=${encodeURIComponent(repository_type)}&accpy=${encodeURIComponent(accpy_version)}&notebook=${encodeURIComponent(notebook)}`);
 
     // Update UI every time a message is received
     eventSource.onmessage = (event) => {


### PR DESCRIPTION
A new parameter is added to the SwanCustomEnvironments extension in
order to automatically open a notebook after the session is launched and
the environment is created.

This new `notebook` argument must be a path for a jupyter notebook
stored in the user's cernbox.

For this purpose, some measure need to be taken, like creating a regex
pattern for ensuring the notebook follows the right structure.

Root path of the `notebook` depends on the provided repository type. If 
it is EOS, the root path remains being CERNBOX_HOME. If Git, the root 
path will be the final path of the repository.

Some extra typing and logging fixes implemented.