### PR TITLE
swancustomenvironments: change defaults, comments, and loggings

### DIFF
--- a/SwanCustomEnvironments/swancustomenvironments/scripts/makenv.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/makenv.sh
@@ -161,17 +161,17 @@ fi
 # Create environment (acc-py or generic)
 if [ -n "$ACCPY_VERSION" ]; then
     source $ACCPY_PATH/base/${ACCPY_VERSION}/setup.sh
-    acc-py venv ${ENV_PATH}
+    acc-py venv ${ENV_PATH} | tee -a "${LOG_FILE}"
 else
     _log "Creating environment ${ENV_NAME} using Generic Python..."
-    python -m venv ${ENV_PATH}
+    python -m venv ${ENV_PATH} | tee -a "${LOG_FILE}"
 fi
 
 _log "ENV_NAME:${ENV_NAME}"
 
 # Make sure the Jupyter server finds the new environment kernel in /home/$USER/.local
 mkdir -p /home/$USER/.local/share/jupyter/kernels
-ln -f -s ${ENV_PATH}/share/jupyter/kernels/${ENV_NAME} /home/$USER/.local/share/jupyter/kernels/${ENV_NAME}
+ln -f -s ${ENV_PATH}/share/jupyter/kernels/${ENV_NAME} /home/$USER/.local/share/jupyter/kernels/${ENV_NAME} | tee -a "${LOG_FILE}"
 
 # Activate the environment
 _log "Setting up the environment..."

--- a/SwanCustomEnvironments/swancustomenvironments/scripts/makenv.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/makenv.sh
@@ -77,10 +77,9 @@ done
 # --------------------------------------------------------------------------------------------
 # Validate input arguments
 
-# Git URL pattern: https://github.com/<username>/<repo_name>(/?) or https://gitlab.cern.ch/<username>/<repo_name>(/?)
-REPO_GIT_PATTERN='^https?:\/\/(github\.com|gitlab\.cern\.ch)\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)\/?$'
-# EOS path pattern: $CERNBOX_HOME/<folder1>/<folder2>/...(/?) or /eos/user/<lowercase_first_letter>/<username>/<folder1>/<folder2>/...(/?)
-# Note: folders after username are optional
+# Git URL pattern: https://github.com/<username>/<repo_name>(/?) or https://gitlab.cern.ch/<username>/<repo_name>((/?)|(.git?))
+REPO_GIT_PATTERN='^https?:\/\/(github\.com|gitlab\.cern\.ch)\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)(\/|\.git)?$'
+# EOS path pattern: $CERNBOX_HOME/<folder1>/<folder2>/...(/?) or /eos/user/<lowercase_first_letter>/<username>/<folder1>?/<folder2>?/...(/?)
 REPO_EOS_PATTERN='^(\$CERNBOX_HOME(\/[^<>|\\:()&;,\/]+)*\/?|\/eos\/user\/[a-z](\/[^<>|\\:()&;,\/]+)+\/?)$'
 
 # Checks if the provided Acc-Py version is valid

--- a/SwanCustomEnvironments/swancustomenvironments/serverextension.py
+++ b/SwanCustomEnvironments/swancustomenvironments/serverextension.py
@@ -22,16 +22,16 @@ class SwanCustomEnvironmentsApiHandler(APIHandler):
         """
         self.set_header("Content-Type", "text/event-stream")
 
-        repository = self.get_query_argument("repo", default=None)
-        repository_type = self.get_query_argument("repo_type", default=None)
-        accpy_version = self.get_query_argument("accpy", default=None)
+        repository = self.get_query_argument("repo", default="")
+        repository_type = self.get_query_argument("repo_type", default="")
+        accpy_version = self.get_query_argument("accpy", default="")
 
         arguments = ["--repo", repository, "--repo_type", repository_type]
-        if accpy_version is not None:
+        if accpy_version:
             arguments.extend(["--accpy", accpy_version])
-        
+
         makenv_process = subprocess.Popen([self.makenv_path, *arguments], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        
+
         for line in iter(makenv_process.stdout.readline, b""):
             self.write(f"data: {line.decode('utf-8')}\n\n")
             self.flush()


### PR DESCRIPTION
- Default for args is an empty string instead of `None`. This is done because bash scripts interpreter `None` as a normal string. Empty strings are the proper way to inform the system the variables are empty.
- Allow the git url pattern to accept `.git` extension
- Comments' explanation simplified
- Redirecting output also when creating the environments and symlinking the kernels (useful in case of errors)