### PR TITLE
swancustomenvironments: New conda environment option

### DIFF
--- a/SwanCustomEnvironments/swancustomenvironments/scripts/builders/accpy.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/builders/accpy.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Checks if the provided Acc-Py version is valid
+if [ ! -e "$ACCPY_PATH/base/$BUILDER_VERSION" ]; then
+    _error "Invalid Acc-Py version (${BUILDER_VERSION})."
+fi
+
+# Set up Acc-Py and create the environment
+source "${ACCPY_PATH}/base/${BUILDER_VERSION}/setup.sh"
+acc-py venv ${ENV_PATH} | tee -a ${LOG_PATH}
+
+# Activate the environment
+_log "Setting up the environment..."
+ACTIVATE_ENV_CMD="source ${ENV_PATH}/bin/activate"
+eval "${ACTIVATE_ENV_CMD}"
+
+# Install packages in the environment
+_log "Installing packages from ${REQ_PATH}..."
+pip install -r "${REQ_PATH}" | tee -a ${LOG_PATH}
+
+# Install the same ipykernel that the Jupyter server uses
+pip install ipykernel==${IPYKERNEL_VERSION} | tee -a ${LOG_FILE}

--- a/SwanCustomEnvironments/swancustomenvironments/scripts/builders/mamba.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/builders/mamba.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Create the environment and install packages
+mamba create -p ${ENV_PATH} --file ${REQ_PATH} -y | tee -a ${LOG_PATH}
+
+# Activate the environment
+_log "Setting up the environment..."
+
+# Needed to use mamba activate without creating a new shell process
+MAMBADIR=$(mktemp -d)
+HOME=${MAMBADIR} mamba init
+ACTIVATE_MAMBA_CMD="source ${MAMBADIR}/.bashrc"
+eval "${ACTIVATE_MAMBA_CMD}"
+
+# Then activate the environment using mamba
+ACTIVATE_ENV_CMD="mamba activate ${ENV_PATH}"
+eval "${ACTIVATE_ENV_CMD}"
+
+# Install the same ipykernel that the Jupyter server uses
+mamba install "ipykernel==${IPYKERNEL_VERSION}" -y | tee -a ${LOG_PATH}
+
+# Source the mamba init script in the user's bash profile
+echo "${ACTIVATE_MAMBA_CMD}" >> /home/$USER/.bash_profile

--- a/SwanCustomEnvironments/swancustomenvironments/scripts/builders/venv.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/builders/venv.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Create the environment
+python3 -m venv ${ENV_PATH} | tee -a ${LOG_PATH}
+
+# Activate the environment
+_log "Setting up the environment..."
+ACTIVATE_ENV_CMD="source ${ENV_PATH}/bin/activate"
+eval "${ACTIVATE_ENV_CMD}"
+
+# Install packages in the environment
+_log "Installing packages from ${REQ_PATH}..."
+pip install -r "${REQ_PATH}" | tee -a ${LOG_PATH}
+
+# Install the same ipykernel that the Jupyter server uses
+pip install ipykernel==${IPYKERNEL_VERSION} | tee -a ${LOG_FILE}

--- a/SwanCustomEnvironments/swancustomenvironments/serverextension.py
+++ b/SwanCustomEnvironments/swancustomenvironments/serverextension.py
@@ -18,24 +18,24 @@ class SwanCustomEnvironmentsApiHandler(APIHandler):
         """
         Gets the arguments from the query string and runs the makenv.sh script with them.
         repo (str): The git URL or absolute unix path to the repository.
-        accpy (str): The version of Accpy to be installed in the environment (optional).
+        repo_type (str): The type of repository (git or eos).
+        builder (str): The builder used for creating the environment.
+        builder_version (str): The version of the specified builder.
         """
         self.set_header("Content-Type", "text/event-stream")
 
         repository = self.get_query_argument("repo", default="")
-        repository_type = self.get_query_argument("repo_type", default="")
-        accpy_version = self.get_query_argument("accpy", default="")
+        repo_type = self.get_query_argument("repo_type", default="")
+        builder = self.get_query_argument("builder", default="")
+        builder_version = self.get_query_argument("builder_version", default="")
 
-        arguments = ["--repo", repository, "--repo_type", repository_type]
-        if accpy_version:
-            arguments.extend(["--accpy", accpy_version])
-
+        arguments = ["--repo", repository, "--repo_type", repo_type, "--builder", builder, "--builder_version", builder_version]
         makenv_process = subprocess.Popen([self.makenv_path, *arguments], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
         for line in iter(makenv_process.stdout.readline, b""):
             self.write(f"data: {line.decode('utf-8')}\n\n")
             self.flush()
-            
+
         self.finish("data: EOF\n\n")
 
 

--- a/SwanCustomEnvironments/swancustomenvironments/templates/customenvs.html
+++ b/SwanCustomEnvironments/swancustomenvironments/templates/customenvs.html
@@ -147,8 +147,9 @@ data-base-url="{{base_url | urlencode}}"
 
     const urlParams = new URLSearchParams(window.location.search);
     var repository = urlParams.get('repo') || "";
-    var repository_type = urlParams.get('repo_type') || "";
-    var accpy_version = urlParams.get('accpy') || "";
+    var repo_type = urlParams.get('repo_type') || "";
+    var builder = urlParams.get('builder') || "";
+    var builder_version = urlParams.get('builder_version') || "";
     var file = `/${urlParams.get('file') || ""}`;
 
     // Environment creation elements
@@ -165,7 +166,7 @@ data-base-url="{{base_url | urlencode}}"
     var modalJupyter = document.getElementById("modal-lab-button");
 
     // Create EventSource to listen for updates from the backend
-    var eventSource = new EventSource(`${base_url}api/customenvs?repo=${encodeURIComponent(repository)}&repo_type=${encodeURIComponent(repository_type)}&accpy=${encodeURIComponent(accpy_version)}`);
+    var eventSource = new EventSource(`${base_url}api/customenvs?repo=${encodeURIComponent(repository)}&repo_type=${encodeURIComponent(repo_type)}&builder=${encodeURIComponent(builder)}&builder_version=${encodeURIComponent(builder_version)}`);
 
     // Update UI every time a message is received
     eventSource.onmessage = (event) => {


### PR DESCRIPTION
Conda (mamba) environments can now be built passing the argument `--conda` into `makenv.sh` script. Some logic and code flow modifications were needed in order to build them sameway as `python-venv`.