### PR TITLE
[SwanCustomEnvs] Prevent two Python kernels from appearing

### DIFF
--- a/SwanCustomEnvironments/swancustomenvironments/scripts/makenv.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/makenv.sh
@@ -177,8 +177,8 @@ fi
 source "${BUILDER_PATH}"
  
 # Make sure the Jupyter server finds the new environment kernel in /home/$USER/.local
-mkdir -p /home/$USER/.local/share/jupyter/kernels
-ln -f -s ${ENV_PATH}/share/jupyter/kernels/${ENV_NAME} /home/$USER/.local/share/jupyter/kernels/${ENV_NAME} | tee -a ${LOG_FILE}
+# We modify the already existing Python3 kernel with the kernel.json of the environment
+ln -f -s ${ENV_PATH}/share/jupyter/kernels/${ENV_NAME}/kernel.json /home/$USER/.local/share/jupyter/kernels/python3/kernel.json | tee -a ${LOG_FILE}
 
 if [[ ${REPO_TYPE} == "git" ]]; then
     # Move the repository from /tmp to the $CERNBOX_HOME/SWAN_projects folder


### PR DESCRIPTION
The swan image already configures the skeleton of a Python3 kernel. When selecting an LCG release, such skeleton is filled with the environment coming from that LCG release.

What we do here is reuse the same skeleton too, but this time, for custom environments, we override the kernel.json of the skeleton with that of the environment.

If instead we create another directory inside kernels with the environment kernel, two Python kernels show up, which is not what we want.