### PR TITLE
swancustomenvironments: Fix line breaks in output and piping to log file

### DIFF
--- a/SwanCustomEnvironments/swancustomenvironments/scripts/builders/accpy.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/builders/accpy.sh
@@ -7,7 +7,7 @@ fi
 
 # Set up Acc-Py and create the environment
 source "${ACCPY_PATH}/base/${BUILDER_VERSION}/setup.sh"
-acc-py venv ${ENV_PATH} | tee -a ${LOG_PATH}
+acc-py venv ${ENV_PATH} | tee -a ${LOG_FILE}
 
 # Activate the environment
 _log "Setting up the environment..."
@@ -16,7 +16,7 @@ eval "${ACTIVATE_ENV_CMD}"
 
 # Install packages in the environment
 _log "Installing packages from ${REQ_PATH}..."
-pip install -r "${REQ_PATH}" | tee -a ${LOG_PATH}
+pip install -r "${REQ_PATH}" | tee -a ${LOG_FILE}
 
 # Install the same ipykernel that the Jupyter server uses
 pip install ipykernel==${IPYKERNEL_VERSION} | tee -a ${LOG_FILE}

--- a/SwanCustomEnvironments/swancustomenvironments/scripts/builders/mamba.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/builders/mamba.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Create the environment and install packages
-mamba create -p ${ENV_PATH} --file ${REQ_PATH} -y | tee -a ${LOG_PATH}
+mamba create -p ${ENV_PATH} --file ${REQ_PATH} -y | tee -a ${LOG_FILE}
 
 # Activate the environment
 _log "Setting up the environment..."
@@ -17,7 +17,7 @@ ACTIVATE_ENV_CMD="mamba activate ${ENV_PATH}"
 eval "${ACTIVATE_ENV_CMD}"
 
 # Install the same ipykernel that the Jupyter server uses
-mamba install "ipykernel==${IPYKERNEL_VERSION}" -y | tee -a ${LOG_PATH}
+mamba install "ipykernel==${IPYKERNEL_VERSION}" -y | tee -a ${LOG_FILE}
 
 # Source the mamba init script in the user's bash profile
 echo "${ACTIVATE_MAMBA_CMD}" >> /home/$USER/.bash_profile

--- a/SwanCustomEnvironments/swancustomenvironments/scripts/builders/venv.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/builders/venv.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Create the environment
-python3 -m venv ${ENV_PATH} | tee -a ${LOG_PATH}
+python3 -m venv ${ENV_PATH} | tee -a ${LOG_FILE}
 
 # Activate the environment
 _log "Setting up the environment..."
@@ -10,7 +10,7 @@ eval "${ACTIVATE_ENV_CMD}"
 
 # Install packages in the environment
 _log "Installing packages from ${REQ_PATH}..."
-pip install -r "${REQ_PATH}" | tee -a ${LOG_PATH}
+pip install -r "${REQ_PATH}" | tee -a ${LOG_FILE}
 
 # Install the same ipykernel that the Jupyter server uses
 pip install ipykernel==${IPYKERNEL_VERSION} | tee -a ${LOG_FILE}

--- a/SwanCustomEnvironments/swancustomenvironments/templates/customenvs.html
+++ b/SwanCustomEnvironments/swancustomenvironments/templates/customenvs.html
@@ -235,8 +235,9 @@ data-base-url="{{base_url | urlencode}}"
                 }
 
                 // Decode the chunk into text and split by newlines
-                const chunked_lines = decoder.decode(value, { stream: true });
-                chunked_lines.split('\n').forEach(message_line => {
+                // Remove the last element (empty string) for avoiding an extra line break
+                const chunked_lines = decoder.decode(value, { stream: true }).split('\n').pop();
+                chunked_lines.forEach(message_line => {
                     if (message_line.startsWith('REPO_PATH')) {
                         const repo_path = message_line.split(':')[1];
                         if (repo_path && repo_path !== '/') {
@@ -260,8 +261,8 @@ data-base-url="{{base_url | urlencode}}"
                             has_failed = true;
                         }
                     }
+                    outputBox.innerHTML += '<br>';
                 });
-                outputBox.innerHTML += '<br>';
             }
         } catch (error) {
             trigger_visual_error(`Error reading stream: ${error}`);


### PR DESCRIPTION
- Insert line breaks between lines instead of chunks (some lines can be empty).
- Fix mistyped variables name from `LOG_PATH` to `LOG_FILE`