### PR TITLE
swancustomenvironments: NXCals, UV and git reclones change

### DIFF
--- a/SwanCustomEnvironments/swancustomenvironments/scripts/builders/accpy.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/builders/accpy.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Activate Rust in order to recognize the uv command
+. "$HOME/.cargo/env"
+
 # Set up Acc-Py and create the environment
 source "${ACCPY_PATH}/base/${BUILDER_VERSION}/setup.sh"
 acc-py venv ${ENV_PATH} | tee -a ${LOG_FILE}
@@ -11,4 +14,4 @@ eval "${ACTIVATE_ENV_CMD}"
 
 # Install packages in the environment and the same ipykernel that the Jupyter server uses
 _log "Installing packages from ${REQ_PATH}..."
-pip install -r "${REQ_PATH}" "ipykernel==${IPYKERNEL_VERSION}" | tee -a ${LOG_FILE}
+uv pip install -i https://acc-py-repo.cern.ch/repository/vr-py-releases/simple --allow-insecure-host acc-py-repo.cern.ch -r "${REQ_PATH}" ${SPARKCONNECTOR} ${SPARKMONITOR} ${PY4J} | tee -a ${LOG_FILE}

--- a/SwanCustomEnvironments/swancustomenvironments/scripts/builders/venv.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/builders/venv.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
+# Activate Rust in order to recognize the uv command
+. "$HOME/.cargo/env"
+
 # Create the environment
-python3 -m venv ${ENV_PATH} | tee -a ${LOG_FILE}
+uv venv ${ENV_PATH} | tee -a ${LOG_FILE}
 
 # Activate the environment
 _log "Setting up the environment..."
@@ -10,4 +13,4 @@ eval "${ACTIVATE_ENV_CMD}"
 
 # Install packages in the environment and the same ipykernel that the Jupyter server uses
 _log "Installing packages from ${REQ_PATH}..."
-pip install -r "${REQ_PATH}" "ipykernel==${IPYKERNEL_VERSION}" | tee -a ${LOG_FILE}
+uv pip install -r "${REQ_PATH}" "ipykernel==${IPYKERNEL_VERSION}" | tee -a ${LOG_FILE}

--- a/SwanCustomEnvironments/swancustomenvironments/serverextension.py
+++ b/SwanCustomEnvironments/swancustomenvironments/serverextension.py
@@ -21,6 +21,7 @@ class SwanCustomEnvironmentsApiHandler(APIHandler):
         repo_type (str): The type of repository (git or eos).
         builder (str): The builder used for creating the environment.
         builder_version (str): The version of the specified builder.
+        nxcals (bool): Whether to include Nxcals in the environment.
         """
         self.set_header("Content-Type", "text/event-stream")
 
@@ -28,8 +29,14 @@ class SwanCustomEnvironmentsApiHandler(APIHandler):
         repo_type = self.get_query_argument("repo_type", default="")
         builder = self.get_query_argument("builder", default="")
         builder_version = self.get_query_argument("builder_version", default="")
+        nxcals = self.get_query_argument("nxcals", default="")
 
-        arguments = ["--repo", repository, "--repo_type", repo_type, "--builder", builder, "--builder_version", builder_version]
+        arguments = ["--repo", repository, "--repo_type", repo_type, "--builder", builder]
+        if builder_version:
+            arguments.extend(("--builder_version", builder_version))
+        if nxcals:
+            arguments.append("--nxcals")
+
         makenv_process = subprocess.Popen([self.makenv_path, *arguments], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
         for line in iter(makenv_process.stdout.readline, b""):

--- a/SwanCustomEnvironments/swancustomenvironments/templates/customenvs.html
+++ b/SwanCustomEnvironments/swancustomenvironments/templates/customenvs.html
@@ -153,6 +153,7 @@ data-base-url="{{base_url | urlencode}}"
     var builder = urlParams.get('builder') || "";
     var builder_version = urlParams.get('builder_version') || "";
     var file = `/${urlParams.get('file') || ""}`;
+    var nxcals = urlParams.get('nxcals') || "";
 
     // Environment creation elements
     var outputBox = document.getElementById('output-box');
@@ -242,7 +243,7 @@ data-base-url="{{base_url | urlencode}}"
     }
 
 
-    fetch(`${base_url}api/customenvs?repo=${encodeURIComponent(repository)}&repo_type=${encodeURIComponent(repo_type)}&builder=${encodeURIComponent(builder)}&builder_version=${encodeURIComponent(builder_version)}`, {
+    fetch(`${base_url}api/customenvs?repo=${encodeURIComponent(repository)}&repo_type=${encodeURIComponent(repo_type)}&builder=${encodeURIComponent(builder)}&builder_version=${encodeURIComponent(builder_version)}&nxcals=${encodeURIComponent(nxcals)}`, {
         method: 'GET',
         headers: get_jh_auth_header(),
     })


### PR DESCRIPTION
When NXCals flag is specified, installs sparkconnector, sparkmonitor and py4j for accpy environments

`UV` is a package manager that has better performance compared to `pip`.
It is used for installing the requirements for accpy and venv, besides creating the `venv` itself

Instead of creating a copy for each clone, implement the following algorithm:
Does SWAN_projects/name_of_repo exist?
If no, clone
If yes, is SWAN_projects/name_of_repo linked with the requested git repo?
If yes, create environment from the requirements.txt in that folder
If no, restart the process with SWAN_projects/name_of_repo_1