### PR TITLE
sparkconnector: Preserve the default value of `extraJavaOptions`

### DIFF
--- a/SparkConnector/setup.py
+++ b/SparkConnector/setup.py
@@ -71,8 +71,7 @@ setup_args = dict(
     cmdclass= cmdclass,
     packages=setuptools.find_packages(),
     install_requires=[
-        "jupyterlab>=4.0.0,<5",
-        "bs4",
+        # "jupyterlab>=4.0.0,<5",
         "swanportallocator",
     ],
     zip_safe=False,

--- a/SparkConnector/sparkconnector/configuration.py
+++ b/SparkConnector/sparkconnector/configuration.py
@@ -1,5 +1,5 @@
 import os, subprocess, shutil, sys, uuid, time, base64, tempfile
-import requests
+import requests, re
 
 from pyspark import SparkConf, SparkContext
 from string import Formatter
@@ -132,11 +132,24 @@ class SparkConfiguration(object):
 
         # Extend conf adding logging of log4j to java options
         base_extra_java_options = "-Dlog4j.configuration=file:%s" % self.connector.log4j_file
-        extra_java_options = conf.get("spark.driver.extraJavaOptions")
-        if extra_java_options:
-            extra_java_options = base_extra_java_options + " " + extra_java_options
+        extra_java_options = " "
+
+        # For customenv sessions, load the default setting for spark.driver.extraJavaOptions from the
+        # spark-defaults.conf file in the environment, if it exists. Later, append the base_java_options.
+        # This is done to preserve the default setting and prevent base_java_options from completely
+        # replacing it. This is necessary e.g. for NXCALS node configuration.
+        if os.environ.get("SOFTWARE_SOURCE") == "customenv":
+            SPARK_DEFAULTS = os.environ.get(
+                "SPARK_DEFAULTS", 
+                os.path.join(os.environ.get("SPARK_HOME"), "conf", "spark-defaults.conf")
+            )
+            if os.path.exists(SPARK_DEFAULTS):
+                for line in open(SPARK_DEFAULTS).readlines():
+                    if line.startswith("spark.driver.extraJavaOptions"):
+                        extra_java_options = line.replace("spark.driver.extraJavaOptions", "").strip()
         else:
-            extra_java_options = base_extra_java_options
+            extra_java_options = conf.get("spark.driver.extraJavaOptions")
+        extra_java_options = f"{extra_java_options} {base_extra_java_options}"
         conf.set("spark.driver.extraJavaOptions", extra_java_options)
 
         # Extend conf ensuring that LD_LIBRARY_PATH on executors is the same as on the driver

--- a/SwanCustomEnvironments/swancustomenvironments/scripts/builders/accpy.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/builders/accpy.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# If using NXCALS, we need to install the Spark extensions and the nxcals package.
+if [ -n "${INSTALL_NXCALS}" ]; then
+    SPARKCONNECTOR="sparkconnector==$(python -c 'import sparkconnector; print(sparkconnector.__version__)')"
+    SPARKMONITOR="sparkmonitor==$(python -c 'import sparkmonitor; print(sparkmonitor.__version__)')"
+    NXCALS="nxcals"
+fi
+
 # Set up Acc-Py and create the environment
 source "${ACCPY_PATH}/base/${BUILDER_VERSION}/setup.sh"
 acc-py venv ${ENV_PATH} | tee -a ${LOG_FILE}

--- a/SwanCustomEnvironments/swancustomenvironments/scripts/makenv.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/makenv.sh
@@ -196,13 +196,6 @@ ENV_PATH="/home/$USER/${ENV_NAME}"
 REQ_PATH="${REPO_PATH}/requirements.txt"
 IPYKERNEL_VERSION=$(python -c "import ipykernel; print(ipykernel.__version__)")
 
-# If using NXCALS, we need to install the Spark extensions and the nxcals package.
-if [ -n "${INSTALL_NXCALS}" ]; then
-    SPARKCONNECTOR="sparkconnector==$(python3 -c 'import sparkconnector; print(sparkconnector.__version__)')"
-    SPARKMONITOR="sparkmonitor==$(python3 -c 'import sparkmonitor; print(sparkmonitor.__version__)')"
-    NXCALS="nxcals"
-fi
-
 # Check if requirements.txt exists in the repository
 if [ ! -f "${REQ_PATH}" ]; then
     _log "ERROR: Requirements file not found (${REQ_PATH})."


### PR DESCRIPTION
Customenv sessions don't have the same configuration as LCG software stack. Which leads to the lost of the spark defaults provided by NXCals. This specially affetcs extraJavaOptions, since its default is being overwritten by SparkConnector, but necessary to preserve, once it contains the list of NXCals instances for running jobs on.