### PR TITLE
swancustomenvironments: Remove `repo_type`

### DIFF
--- a/SwanCustomEnvironments/swancustomenvironments/scripts/builders/accpy.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/builders/accpy.sh
@@ -2,7 +2,7 @@
 
 # Set up Acc-Py and create the environment
 source "${ACCPY_PATH}/base/${BUILDER_VERSION}/setup.sh"
-acc-py venv ${ENV_PATH} | tee -a ${LOG_FILE}
+acc-py venv ${ENV_PATH} 2>&1 | tee -a ${LOG_FILE}
 
 # Activate the environment
 _log "Setting up the environment..."

--- a/SwanCustomEnvironments/swancustomenvironments/scripts/builders/venv.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/builders/venv.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Create the environment
-python3 -m venv ${ENV_PATH} | tee -a ${LOG_FILE}
+python3 -m venv ${ENV_PATH} 2>&1 | tee -a ${LOG_FILE}
 
 # Activate the environment
 _log "Setting up the environment..."
@@ -10,4 +10,4 @@ eval "${ACTIVATE_ENV_CMD}"
 
 # Install packages in the environment and the same ipykernel that the Jupyter server uses
 _log "Installing packages from ${REQ_PATH}..."
-pip install -r "${REQ_PATH}" "ipykernel==${IPYKERNEL_VERSION}" | tee -a ${LOG_FILE}
+pip install -r "${REQ_PATH}" "ipykernel==${IPYKERNEL_VERSION}" 2>&1 | tee -a ${LOG_FILE}

--- a/SwanCustomEnvironments/swancustomenvironments/scripts/makenv.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/makenv.sh
@@ -19,7 +19,7 @@ GIT_HOME="$HOME/SWAN_projects" # Path where git repositories are stored
 
 _log () {
     if [ "$*" == "ERROR:"* ] || [ "$*" == "WARNING:"* ] || [ "${JUPYTER_DOCKER_STACKS_QUIET}" == "" ]; then
-        echo "$@" | tee -a ${LOG_FILE}
+        echo "$@" 2>&1 | tee -a ${LOG_FILE}
     fi
 }
 
@@ -140,11 +140,11 @@ if [[ "$REPOSITORY" =~ $REPO_GIT_PATTERN ]]; then
     ENV_NAME="${REPO_NAME}_env"
 
     define_repo_path $REPO_NAME
-    # If the repo was not previously cloned, clone it.
+    # If the repo was not previous cloned yet, clone it.
     # Otherwise, use the existing one in the SWAN_projects folder
     if [ ! -d "${GIT_REPO_PATH}" ]; then
         _log "Cloning the repository from ${REPOSITORY}..."
-        git clone $REPOSITORY -q "${TMP_REPO_PATH}" | tee -a ${LOG_FILE}
+        git clone $REPOSITORY -q "${TMP_REPO_PATH}" 2>&1 | tee -a ${LOG_FILE}
         if [ $? -ne 0 ]; then
             _log "ERROR: Failed to clone Git repository" && exit 1
         fi
@@ -181,7 +181,7 @@ HOME=/home/$USER source "${BUILDER_PATH}"
 
 # Install environment kernel.
 # Setting JUPYTER_PATH prevents ipykernel installation from complaining about non-found kernelspec
-JUPYTER_PATH=${ENV_PATH}/share/jupyter python -m ipykernel install --name "${ENV_NAME}" --display-name "Python (${ENV_NAME})" --prefix "${ENV_PATH}" | tee -a ${LOG_FILE}
+JUPYTER_PATH=${ENV_PATH}/share/jupyter python -m ipykernel install --name "${ENV_NAME}" --display-name "Python (${ENV_NAME})" --prefix "${ENV_PATH}" 2>&1 | tee -a ${LOG_FILE}
 
 # Make sure the Jupyter server finds the new environment kernel in /home/$USER/.local
 # We modify the already existing Python3 kernel with the kernel.json of the environment

--- a/SwanCustomEnvironments/swancustomenvironments/serverextension.py
+++ b/SwanCustomEnvironments/swancustomenvironments/serverextension.py
@@ -18,7 +18,6 @@ class SwanCustomEnvironmentsApiHandler(APIHandler):
         """
         Gets the arguments from the query string and runs the makenv.sh script with them.
         repo (str): The git URL or absolute unix path to the repository.
-        repo_type (str): The type of repository (git or eos).
         builder (str): The builder used for creating the environment.
         builder_version (str): The version of the specified builder.
         nxcals (bool): Whether to include NXCALS and Spark extensions in the environment.
@@ -26,12 +25,11 @@ class SwanCustomEnvironmentsApiHandler(APIHandler):
         self.set_header("Content-Type", "text/event-stream")
 
         repository = self.get_query_argument("repo", default="")
-        repo_type = self.get_query_argument("repo_type", default="")
         builder = self.get_query_argument("builder", default="")
         builder_version = self.get_query_argument("builder_version", default="")
         nxcals = self.get_query_argument("nxcals", default="")
 
-        arguments = ["--repo", repository, "--repo_type", repo_type, "--builder", builder]
+        arguments = ["--repo", repository, "--builder", builder]
         if builder_version:
             arguments.extend(("--builder_version", builder_version))
         if nxcals:

--- a/SwanCustomEnvironments/swancustomenvironments/templates/customenvs.html
+++ b/SwanCustomEnvironments/swancustomenvironments/templates/customenvs.html
@@ -149,7 +149,6 @@ data-base-url="{{base_url | urlencode}}"
 
     const urlParams = new URLSearchParams(window.location.search);
     var repository = urlParams.get('repo') || "";
-    var repo_type = urlParams.get('repo_type') || "";
     var builder = urlParams.get('builder') || "";
     var builder_version = urlParams.get('builder_version') || "";
     var file = `/${urlParams.get('file') || ""}`;
@@ -242,8 +241,7 @@ data-base-url="{{base_url | urlencode}}"
         }
     }
 
-
-    fetch(`${base_url}api/customenvs?repo=${encodeURIComponent(repository)}&repo_type=${encodeURIComponent(repo_type)}&builder=${encodeURIComponent(builder)}&builder_version=${encodeURIComponent(builder_version)}&nxcals=${encodeURIComponent(nxcals)}`, {
+    fetch(`${base_url}api/customenvs?repo=${encodeURIComponent(repository)}&builder=${encodeURIComponent(builder)}&builder_version=${encodeURIComponent(builder_version)}&nxcals=${encodeURIComponent(nxcals)}`, {
         method: 'GET',
         headers: get_jh_auth_header(),
     })


### PR DESCRIPTION
Changes on the way repository was manage due to its previous type flexibility. Now only git repos are taking into account.
Pipe stderr to stdout in order to also write the error messages in the log file