### PR TITLE
swancustomenvironments: Implementation of sparkconnector bypass

### DIFF
--- a/SwanCustomEnvironments/swancustomenvironments/scripts/builders/accpy.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/builders/accpy.sh
@@ -5,6 +5,7 @@ if [ -n "${INSTALL_NXCALS}" ]; then
     SPARKCONNECTOR="sparkconnector==$(python -c 'import sparkconnector; print(sparkconnector.__version__)')"
     SPARKMONITOR="sparkmonitor==$(python -c 'import sparkmonitor; print(sparkmonitor.__version__)')"
     NXCALS="nxcals"
+    SWANPORTALLOCATOR="swanportallocator" # TODO: Remove swanportallocator installation when the SparkConnector package gets properly updated
 fi
 
 # Set up Acc-Py and create the environment
@@ -18,4 +19,13 @@ eval "${ACTIVATE_ENV_CMD}"
 
 # Install packages in the environment and the same ipykernel that the Jupyter server uses
 _log "Installing packages from ${REQ_PATH}..."
-pip install -r "${REQ_PATH}" "ipykernel==${IPYKERNEL_VERSION}" ${SPARKCONNECTOR} ${SPARKMONITOR} ${NXCALS} | tee -a ${LOG_FILE}
+pip install -r "${REQ_PATH}" "ipykernel==${IPYKERNEL_VERSION}" ${NXCALS} ${SPARKMONITOR} ${SWANPORTALLOCATOR} 2>&1 | tee -a ${LOG_FILE} # TODO
+
+
+# -------------- HACK SECTION --------------
+# Install SWANPORTALLOCATOR separately, install SparkConnector without its dependencies and change the configuration file
+# TODO: Remove this when the SparkConnector package gets properly updated
+if [ -n "${INSTALL_NXCALS}" ]; then
+    pip install ${SPARKCONNECTOR} --no-deps 2>&1 | tee -a ${LOG_FILE}
+    wget https://raw.githubusercontent.com/swan-cern/jupyter-extensions/refs/heads/swan-on-tn/SparkConnector/sparkconnector/configuration.py -O ${ENV_PATH}/lib/python3.11/site-packages/sparkconnector/configuration.py 2>&1 | tee -a ${LOG_FILE}
+fi


### PR DESCRIPTION
SparkConnector cannot be updated by now. Installing it by git repo takes much longer. So we install `swanportallocator` separately and  the current SparkConnector package with its dependencies longside