### PR TITLE
swancustomenvironments: Create a middle layer environment

### DIFF
--- a/SwanCustomEnvironments/swancustomenvironments/scripts/builders/accpy.sh
+++ b/SwanCustomEnvironments/swancustomenvironments/scripts/builders/accpy.sh
@@ -6,6 +6,20 @@ if [ -n "${INSTALL_NXCALS}" ]; then
     SPARKMONITOR="sparkmonitor==$(python -c 'import sparkmonitor; print(sparkmonitor.__version__)')"
     NXCALS="nxcals"
     SPARKCONNECTOR_DEPENDENCIES="swanportallocator requests" # TODO: Remove swanportallocator and requests installation when the SparkConnector package gets properly updated
+    
+    # Create a middle layer for installing Spark extensions, putting them apart from the user environment
+    SWAN_ENV="${HOME}/swan"
+    python -m venv ${SWAN_ENV} 2>&1
+    source ${SWAN_ENV}/bin/activate
+    SWAN_PACKAGES_PATH=$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
+
+    pip install ${SPARKMONITOR} ${SPARKCONNECTOR_DEPENDENCIES} 2>&1
+
+    # -------------- HACK SECTION --------------
+    # Install SPARKCONNECTOR_DEPENDENCIES separately, install SparkConnector without its dependencies and change the configuration file
+    # TODO: Remove this when the SparkConnector package gets properly updated
+    pip install ${SPARKCONNECTOR} --no-deps 2>&1
+    wget https://raw.githubusercontent.com/swan-cern/jupyter-extensions/refs/heads/swan-on-tn/SparkConnector/sparkconnector/configuration.py -O ${SWAN_PACKAGES_PATH}/sparkconnector/configuration.py 2>&1
 fi
 
 # Set up Acc-Py and create the environment
@@ -19,16 +33,14 @@ eval "${ACTIVATE_ENV_CMD}"
 
 # Install packages in the environment and the same ipykernel that the Jupyter server uses
 _log "Installing packages from ${REQ_PATH}..."
-pip install -r "${REQ_PATH}" "ipykernel==${IPYKERNEL_VERSION}" ${NXCALS} ${SPARKMONITOR} ${SPARKCONNECTOR_DEPENDENCIES} 2>&1 # TODO
+pip install -r "${REQ_PATH}" "ipykernel==${IPYKERNEL_VERSION}" ${NXCALS} 2>&1
 if [ $? -ne 0 ]; then
     exit 1
 fi
 
-
-# -------------- HACK SECTION --------------
-# Install SPARKCONNECTOR_DEPENDENCIES separately, install SparkConnector without its dependencies and change the configuration file
-# TODO: Remove this when the SparkConnector package gets properly updated
+# Inject middle layer packages into the user environment by adding a .pth file to
+# the environment site-packages that contains the path to the middle layer site-packages
 if [ -n "${INSTALL_NXCALS}" ]; then
-    pip install ${SPARKCONNECTOR} --no-deps 2>&1
-    wget https://raw.githubusercontent.com/swan-cern/jupyter-extensions/refs/heads/swan-on-tn/SparkConnector/sparkconnector/configuration.py -O ${ENV_PATH}/lib/python3.11/site-packages/sparkconnector/configuration.py 2>&1
+    USER_PACKAGES_PATH=$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
+    echo ${SWAN_PACKAGES_PATH} > ${USER_PACKAGES_PATH}/$(basename ${SWAN_ENV}).pth
 fi


### PR DESCRIPTION
Create a `swan` environment for installing SparkConnector and SparkMonitor, in order to avoid their presence among the other user packages in the created environment by the user.

Afterwards, create a `.pth` file among the user packages for adding these Spark packages to the user context.

This way, when user `pip freeze` his environment, it won't contain Spark packages, keeping its integrity. A `--local` flag needs to be passed in order to preserve its scope restricted, ignoring Spark extensions.