### PR TITLE
swancontents: Use async file contents manager

### DIFF
--- a/SwanContents/swancontents/filemanager/eos/fileio.py
+++ b/SwanContents/swancontents/filemanager/eos/fileio.py
@@ -1,7 +1,7 @@
-from jupyter_server.services.contents.fileio import FileManagerMixin
+from jupyter_server.services.contents.fileio import AsyncFileManagerMixin
 from jupyter_server.utils import url_path_join
 from tornado.web import HTTPError
-from contextlib import contextmanager
+from contextlib import contextmanager, asynccontextmanager
 import io, os, nbformat
 import subprocess
 
@@ -82,7 +82,7 @@ def atomic_writing(path, text=True, encoding='utf-8', log=None, **kwargs):
             subprocess.run(["setfattr","-x", "user.fusex.rename.version", dirname])
 
 
-class SwanFileManagerMixin(FileManagerMixin):
+class SwanFileManagerMixin(AsyncFileManagerMixin):
     """
     Mixin for ContentsAPI classes that interact with the filesystem.
 

--- a/SwanContents/swancontents/filemanager/eos/fileio.py
+++ b/SwanContents/swancontents/filemanager/eos/fileio.py
@@ -107,58 +107,6 @@ class SwanFileManagerMixin(FileManagerMixin):
         else:
             return super()._get_os_path(path)
 
-    def _save_notebook(self, os_path, nb, capture_validation_error=None):
-        """
-        Save a notebook on EOS via FUSE with the default routine.
-        Plus, store a copy of the same notebook on the host machine via docker volume.
-        """
-        import time
-        def write_notebook_to_local(path, content, encoding='utf-8'):
-            try:
-                fout = io.open(path, 'w', encoding=encoding)
-                nbformat.write(content, fout, version=nbformat.NO_CONVERT)
-                fout.flush()
-                os.fsync(fout.fileno())
-                fout.close()
-            except:
-                pass
-            return
-
-        def read_notebook_from_local(path, encoding='utf-8', as_version=4):
-            try:
-                with io.open(path, 'r', encoding=encoding) as fin:
-                    return nbformat.read(fin, as_version=as_version)
-            except:
-                return nbformat.v4.new_notebook()
-
-        # If the path on the host is defined, save a copy of the notebook there
-        if ('USERDATA_PATH' in os.environ and os.path.isdir(os.environ['USERDATA_PATH'])):
-            # Define the filename for the local copy
-            dirname, basename = os.path.split(os_path)
-            local_fname = "-".join([os.environ['USER'], "nb", str(int(time.time())), dirname.replace(os.sep, "-"), basename])
-            local_path = os.path.join(os.environ['USERDATA_PATH'], local_fname)
-
-            # Write the notebook locally and check for consistency
-            local_retry = 10
-            write_notebook_to_local(local_path, nb)
-            for i in range(0, local_retry):
-                read_nb = read_notebook_from_local(local_path)
-                if (nb == read_nb):
-                    break
-                else:
-                    #time.sleep(0.1*2**i)    # Backoff on retry (100ms to 51.2s)
-                    time.sleep(0.5)
-                    write_notebook_to_local(local_path, nb)
-
-        # In all cases, save on eos via fuse
-        with self.atomic_writing(os_path, encoding="utf-8") as f:
-            nbformat.write(
-                nb,
-                f,
-                version=nbformat.NO_CONVERT,
-                capture_validation_error=capture_validation_error,
-            )
-
     @contextmanager
     def atomic_writing(self, os_path, *args, **kwargs):
         """Overload the default atomic_writing to use a different write method

--- a/SwanContents/swancontents/filemanager/swan_eos_filemanager.py
+++ b/SwanContents/swancontents/filemanager/swan_eos_filemanager.py
@@ -1,5 +1,5 @@
 # from notebook import transutils #needs to be imported before Jupyter File Manager
-from jupyter_server.services.contents.largefilemanager import LargeFileManager
+from jupyter_server.services.contents.largefilemanager import AsyncLargeFileManager
 from .eos.fileio import SwanFileManagerMixin
 from .eos.handlers import SwanAuthenticatedFileHandler
 from .projects_mixin import ProjectsMixin
@@ -9,7 +9,7 @@ import os
 import shutil
 
 
-class SwanEosFileManager(ProjectsMixin, SwanFileManagerMixin, LargeFileManager):
+class SwanEosFileManager(ProjectsMixin, SwanFileManagerMixin, AsyncLargeFileManager):
     """
     SWAN File Manager Wrapper for content on EOS
     Adds "Project" as a new type of folder


### PR DESCRIPTION
Use an async file contents manager to have async file operations, such as for listing and saving files. This was implemented to solve an issue that was being caused by users not being able to type in terminal when they would open a folder with a large amount of files in the file browser of JupyterLab

By separating the file operations in different threads and releasing control of the main one, the issue has been fixed