### PR TITLE
sparkconnector: Prevention for SwanCustomEnvironments

### DIFF
--- a/SparkConnector/sparkconnector/configuration.py
+++ b/SparkConnector/sparkconnector/configuration.py
@@ -131,14 +131,15 @@ class SparkConfiguration(object):
             conf.set(name, value)
 
         # Fill extra_java_options as a concatenation of:
-        # 1. Options configured by the user via the UI of SparkConnector
-        # 2. SPARK_DRIVER_EXTRA_JAVA_OPTIONS variable, set for example to load required NXCALS settings
+        # 1. SPARK_DRIVER_EXTRA_JAVA_OPTIONS variable, set for example to load required NXCALS settings
+        # 2. Options configured by the user via the UI of SparkConnector
         # 3. Base Java options with log4j configuration
-        user_extra_java_options = conf.get("spark.driver.extraJavaOptions", "")
+        # User's options should take precedence over the base option
         env_extra_java_options = os.environ.get("SPARK_DRIVER_EXTRA_JAVA_OPTIONS", "").strip()
+        user_extra_java_options = conf.get("spark.driver.extraJavaOptions", "")
         logging_extra_java_options = "-Dlog4j2.configurationFile=%s" % self.connector.log4j_file
         
-        extra_java_options = f"{user_extra_java_options} {env_extra_java_options} {logging_extra_java_options}"
+        extra_java_options = f"{env_extra_java_options} {user_extra_java_options} {logging_extra_java_options}"
         conf.set("spark.driver.extraJavaOptions", extra_java_options)
 
         # Extend conf ensuring that LD_LIBRARY_PATH on executors is the same as on the driver

--- a/SparkConnector/sparkconnector/configuration.py
+++ b/SparkConnector/sparkconnector/configuration.py
@@ -132,11 +132,24 @@ class SparkConfiguration(object):
 
         # Extend conf adding logging of log4j to java options
         base_extra_java_options = "-Dlog4j2.configurationFile=%s" % self.connector.log4j_file
-        extra_java_options = conf.get("spark.driver.extraJavaOptions")
-        if extra_java_options:
-            extra_java_options = base_extra_java_options + " " + extra_java_options
+        extra_java_options = " "
+
+        # For customenv sessions, load the default setting for spark.driver.extraJavaOptions from the
+        # spark-defaults.conf file in the environment, if it exists. Later, append the base_java_options.
+        # This is done to preserve the default setting and prevent base_java_options from completely
+        # replacing it. This is necessary e.g. for NXCALS node configuration.
+        if os.environ.get("SOFTWARE_SOURCE") == "customenv":
+            SPARK_DEFAULTS = os.environ.get(
+                "SPARK_DEFAULTS", 
+                os.path.join(os.environ.get("SPARK_HOME"), "conf", "spark-defaults.conf")
+            )
+            if os.path.exists(SPARK_DEFAULTS):
+                for line in open(SPARK_DEFAULTS).readlines():
+                    if line.startswith("spark.driver.extraJavaOptions"):
+                        extra_java_options = line.replace("spark.driver.extraJavaOptions", "").strip()
         else:
-            extra_java_options = base_extra_java_options
+            extra_java_options = conf.get("spark.driver.extraJavaOptions")
+        extra_java_options = f"{extra_java_options} {base_extra_java_options}"
         conf.set("spark.driver.extraJavaOptions", extra_java_options)
 
         # Extend conf ensuring that LD_LIBRARY_PATH on executors is the same as on the driver


### PR DESCRIPTION
- Customenv sessions do not have the same configuration as the LCG software stack. This leads to the loss of the Spark defaults provided by NXCals. This especially affects extraJavaOptions, since its default is being replaced by SparkConnector, but it is necessary to preserve it since it contains the list of NXCals instances to run the jobs.
- With `SPARK_DRIVER_EXTRA_JAVA_OPTIONS` defined as environment variable in the kernel, it configures `extraJavaOptions` with the default spark configuration.
- User options take now precedence over the default ones
