### PR TITLE
Update image used by Spark on K8S

### DIFF
--- a/SparkConnector/sparkconnector/configuration.py
+++ b/SparkConnector/sparkconnector/configuration.py
@@ -270,7 +270,7 @@ class SparkK8sConfiguration(SparkConfiguration):
 
         # Set K8s configuration
         conf.set('spark.kubernetes.namespace', os.environ.get('SPARK_USER'))
-        conf.set('spark.kubernetes.container.image', 'gitlab-registry.cern.ch/db/spark-service/docker-registry/swan:alma9-20240123')
+        conf.set('spark.kubernetes.container.image', 'gitlab-registry.cern.ch/db/spark-service/docker-registry/swan:alma9-20250522')
         conf.set('spark.master', self._retrieve_k8s_master(os.environ.get('KUBECONFIG')))
 
         # Configure shuffle if running on K8s with Spark 3.x.x


### PR DESCRIPTION
This is to update the container image used by Spark on k8s to the latest version of Alma9 as of 20250522.