### PR TITLE
swandask: Fix error when connecting to HTCondor clusters on `bleeding edge`

### DIFF
--- a/SwanDask/swandask/app.py
+++ b/SwanDask/swandask/app.py
@@ -12,6 +12,8 @@ from tornado import ioloop, web
 # Otherwise, we would need to configure the templates
 from jupyter_server.base.handlers import JupyterHandler, APIHandler
 JupyterHandler.write_error = APIHandler.write_error
+from traitlets.config import Configurable
+from jupyter_server.auth import IdentityProvider
 
 class WebApp:
     pass
@@ -46,11 +48,15 @@ def main():
     # Prevent 403 errors when querying the dashboard server
     _set_dashboard_whitelist()
 
+    # Create a dummy Configurable parent for the IdentityProvider
+    identity_provider = IdentityProvider(parent=Configurable())
+
     # If no remote access allowed, Jupyter will check if we're serving from https://localhost
     app = web.Application(
         base_url=args.base_url,
         allow_remote_access=True,
         cookie_secret=urandom(32),
+        identity_provider=identity_provider
     )
 
     server_app = WebApp()


### PR DESCRIPTION
In spite of fixing the bugs presented in the `bleeding edge` software stack when connecting to HTCondor cluster, the 403 error still persists.

```
2025-07-03 15:08:42,651 - SwanDask - INFO - Running SwanDask on port 41373 with base url /user/rhenriqu/
[W 2025-07-03 15:08:43.470 ServerApp] 403 GET /user/rhenriqu/dask/clusters?1751548120525 (rhenriqu@127.0.0.1) 2725.25ms
[W 2025-07-03 15:08:43.471 ServerApp] 403 GET /user/rhenriqu/dask/clusters?1751548120543 (rhenriqu@127.0.0.1) 2694.93ms
```