### PR TITLE
swancontents: Pass the value of require_hash down the stack

### DIFF
--- a/SwanContents/swancontents/filemanager/projects_mixin.py
+++ b/SwanContents/swancontents/filemanager/projects_mixin.py
@@ -107,7 +107,7 @@ class ProjectsMixin(HasTraits):
             with self.perm_to_403():
                 await super()._save_file(os.path.join(os_path, self.swan_default_file), '', 'text')
 
-    async def get(self, path, content=True, type=None, format=None, require_hash=None):
+    async def get(self, path, content=True, type=None, format=None, require_hash=False):
         """ Get info from a path"""
 
         path = path.strip('/')
@@ -130,7 +130,7 @@ class ProjectsMixin(HasTraits):
             model = await self._proj_model(path, content=content)
 
         else:
-            model = await super().get(path, content, type, format)
+            model = await super().get(path, content, type, format, require_hash)
         return model
 
     async def save(self, model, path=''):


### PR DESCRIPTION
In more recent versions of jupyter_server, require_hash argument no longer accepts the value None. After upgrading to JupyterLab 4.5.2 (which also upgraded other jupyter components), the jupyter_server forced to set the hash and hash_algorithm parameters and so `require_hash` must be true in order not to show an error regarding missing parameters to the user.

The problem was that we were not passing such argument down the function call and so it was setting it to `False` as default, thus showing the aforementioned error about the missing parameters.