### PR TITLE
Use http for Spark WebUI when running Spark on K8S

### DIFF
--- a/SparkConnector/sparkconnector/configuration.py
+++ b/SparkConnector/sparkconnector/configuration.py
@@ -347,7 +347,7 @@ class SparkK8sConfiguration(SparkConfiguration):
                                               '&var-UserName=' + self.get_spark_user() + \
                                               '&var-ApplicationId=' + sc._conf.get('spark.app.id')
 
-            webui_url = 'https://' + sc._conf.get('spark.driver.host') + ':' + sc._conf.get('spark.ui.port')
+            webui_url = 'http://' + sc._conf.get('spark.driver.host') + ':' + sc._conf.get('spark.ui.port')
             conn_config['sparkwebui'] = webui_url
 
         return conn_config


### PR DESCRIPTION
This is to revert to using http for Spark WebUI when running Spark on K8S.
