### PR TITLE
SparkConnector: set Kubernetes shuffle defaults unconditionally

### DIFF
--- a/SparkConnector/sparkconnector/configuration.py
+++ b/SparkConnector/sparkconnector/configuration.py
@@ -365,10 +365,9 @@ class SparkK8sConfiguration(SparkConfiguration):
         conf.set('spark.kubernetes.container.image', 'gitlab-registry.cern.ch/swan/spark/docker-registry/swan:alma9-20260319')
         conf.set('spark.master', self._retrieve_k8s_master(self._get_kubeconfig_path()))
 
-        # Configure shuffle if running on K8s with Spark 3.x.x
-        if self.get_spark_version().split('.')[0]=='3':
-            conf.set('spark.shuffle.service.enabled', 'false')
-            conf.set('spark.dynamicAllocation.shuffleTracking.enabled', 'true')
+        # There is no shuffle service for K8S
+        conf.set('spark.shuffle.service.enabled', 'false')
+        conf.set('spark.dynamicAllocation.shuffleTracking.enabled', 'true')
 
         # Ensure that Spark ENVs on executors are the same as on the driver
         conf.set('spark.executorEnv.PYTHONPATH', os.environ.get('PYTHONPATH'))


### PR DESCRIPTION
SparkConnector: set Kubernetes shuffle defaults unconditionally, use the config from Spark 3 also for Spark 4. Spark 2 is no more supported.