### PR TITLE
HdfsBrowser: Fix building HdfsBrowser

### DIFF
--- a/HdfsBrowser/MANIFEST.in
+++ b/HdfsBrowser/MANIFEST.in
@@ -10,8 +10,8 @@ include nbextension/webpack.config.js
 include ts*.json
 include yarn.lock
 include nbextension/yarn.lock
-include hdfsbrowser/labextension/
-include hdfsbrowser/nbextension/
+graft hdfsbrowser/labextension
+graft hdfsbrowser/nbextension
 
 # Javascript files
 graft src


### PR DESCRIPTION
The build currently fails when building e.g. with `uv build HdfsBrowser`:

```
subprocess.CalledProcessError: Command '['/home/troun/.cache/uv/builds-v0/.tmpGWAEcz/bin/jlpm', 'run', 'build:prod']' returned non-zero exit status 1.
  × Failed to build `/home/troun/dev/swan/jupyter-extensions/HdfsBrowser`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)
      hint: This usually indicates a problem with the package or the build environment.
```


