### PR TITLE
Add a CI workflow which builds packages

### DIFF
--- a/.github/scripts/detect_changed_packages.py
+++ b/.github/scripts/detect_changed_packages.py
@@ -1,0 +1,45 @@
+"""Detect which top-level packages are touched by the current PR/push.
+
+Writes a JSON array of changed package names to ``$GITHUB_OUTPUT``.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+PACKAGES = sorted(
+    pkg.name for pkg in Path.cwd().glob("*/") if (pkg / "pyproject.toml").exists()
+)
+
+
+def main():
+    base = os.environ["BASE_SHA"]
+    head = os.environ["HEAD_SHA"]
+
+    diff = subprocess.run(
+        ["git", "diff", "--name-only", base, head],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    changed = diff.stdout.splitlines()
+
+    print("Changed files:")
+    for path in changed:
+        print(f"  {path}")
+
+    matched = [
+        pkg for pkg in PACKAGES if any(path.startswith(f"{pkg}/") for path in changed)
+    ]
+    print("Matched packages:")
+    for pkg in matched:
+        print(f"  {pkg}")
+
+    with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+        f.write(f"packages={json.dumps(matched)}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  detect-changes:
+    name: Detect changed packages
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.filter.outputs.packages }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.14"
+
+      - name: Detect changed packages
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: uv run --no-project .github/scripts/detect_changed_packages.py
+
+  build:
+    name: Build ${{ matrix.package }}
+    needs: detect-changes
+    if: needs.detect-changes.outputs.packages != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.detect-changes.outputs.packages) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"  # Some packages depend indirectly on the `pipes` module, removed in Python 3.13
+
+      - name: Build ${{ matrix.package }} 📦
+        run: uv build ${{ matrix.package }}


### PR DESCRIPTION
For pushes to master and pull requests, this workflow finds the affected packages and tries to build them to ensure there are no issues.

Example PR/CI run here: https://github.com/tomasr8/jupyter-extensions/pull/1 (note that HdfsBrowser is expected to fail there)