### PR TITLE
swan-ml: Remove conditional type imports

### DIFF
--- a/SwanML/swan_ml/ml.py
+++ b/SwanML/swan_ml/ml.py
@@ -1,11 +1,9 @@
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import jwt
 import kfp
 
-if TYPE_CHECKING:
-    from swan_ml.config import SwanML
+from swan_ml.config import SwanML
 
 
 def read_token(path: Path) -> str:


### PR DESCRIPTION
This would require `from __future__ import annotations` on older Python versions so let's just simplify it..