### PR TITLE
swan-ml: Ignore `Forbidden` ApiException from the kfp client

### DIFF
--- a/SwanML/swan_ml/handlers.py
+++ b/SwanML/swan_ml/handlers.py
@@ -25,7 +25,7 @@ class ListRunsHandler(APIHandler):
         config = self.swan_config
 
         loop = asyncio.get_running_loop()
-        result = await loop.run_in_executor(None, fetch_runs, page_size, page_token, config)
+        result = await loop.run_in_executor(None, fetch_runs, page_size, page_token, config, self.log)
         self.finish(json.dumps(result))
 
 

--- a/SwanML/swan_ml/handlers.py
+++ b/SwanML/swan_ml/handlers.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 
 import tornado.web
 from jupyter_server.base.handlers import APIHandler
@@ -10,8 +9,6 @@ from jupyter_server.utils import url_path_join
 
 from swan_ml.config import SwanML
 from swan_ml.ml import fetch_runs
-
-logger = logging.getLogger(__name__)
 
 
 class ListRunsHandler(APIHandler):
@@ -43,8 +40,4 @@ def setup_handlers(web_app, config: SwanML):
             ListRunsHandler,
         ),
     ]
-
     web_app.add_handlers(".*", handlers)
-    logger.info(
-        "Registered swan-ml API handlers at %sapi/mlcern/", base_url
-    )

--- a/SwanML/swan_ml/ml.py
+++ b/SwanML/swan_ml/ml.py
@@ -1,7 +1,9 @@
+import logging
 from pathlib import Path
 
 import jwt
 import kfp
+import kfp_server_api
 
 from swan_ml.config import SwanML
 
@@ -25,18 +27,31 @@ def get_kfp_client(token_path: Path, host: str) -> kfp.Client:
     )
 
 
-def fetch_runs(page_size: int, page_token: str, config: SwanML) -> dict:
+def fetch_runs(page_size: int, page_token: str, config: SwanML, log: logging.Logger) -> dict:
     """Fetch runs from Kubeflow."""
 
     client = get_kfp_client(
         token_path=Path(config.token_path),
         host=config.kubeflow_host,
     )
-    response = client.list_runs(
-        page_size=page_size,
-        page_token=page_token,
-        sort_by="created_at desc",
-    )
+    try:
+        response = client.list_runs(
+            page_size=page_size,
+            page_token=page_token,
+            sort_by="created_at desc",
+        )
+    except kfp_server_api.exceptions.ApiException as e:
+        if e.reason == "Forbidden":
+            # This can happen if the user never logged in to Kubeflow before.
+            # In this case, we just return an empty list instead of showing an error.
+            log.info("Kubeflow returned 403 Forbidden when listing runs; returning empty list")
+            return {
+                "runs": [],
+                "next_page_token": '',
+                "total_size": 0,
+            }
+        raise
+
 
     runs = []
     for run in response.runs or []:


### PR DESCRIPTION
This exception is raised when the user has never logged into Kubeflow before. In that case it's better to just show no runs instead of an error.