### PR TITLE
Fix `is_repo` check when rebuilding frontend assets

### DIFF
--- a/HdfsBrowser/setup.py
+++ b/HdfsBrowser/setup.py
@@ -54,7 +54,7 @@ js_command = combine_commands(
     ensure_targets(jstargets),
 )
 
-is_repo = os.path.exists(os.path.join(HERE, ".git"))
+is_repo = os.path.exists(os.path.join(HERE, "..", ".git"))
 if is_repo:
     cmdclass["jsdeps"] = js_command
 else:

--- a/SparkConnector/setup.py
+++ b/SparkConnector/setup.py
@@ -51,7 +51,7 @@ js_command = combine_commands(
     ensure_targets(jstargets),
 )
 
-is_repo = os.path.exists(os.path.join(HERE, ".git"))
+is_repo = os.path.exists(os.path.join(HERE, "..", ".git"))
 if is_repo:
     cmdclass["jsdeps"] = js_command
 else:

--- a/SwanHelp/setup.py
+++ b/SwanHelp/setup.py
@@ -55,7 +55,7 @@ js_command = combine_commands(
     ensure_targets(jstargets),
 )
 
-is_repo = os.path.exists(os.path.join(HERE, ".git"))
+is_repo = os.path.exists(os.path.join(HERE, "..", ".git"))
 if is_repo:
     cmdclass["jsdeps"] = js_command
 else:


### PR DESCRIPTION
This check is meant to skip rebuilding frontend assets when not inside a git repo (e.g. an sdist) but the check is incorrect. This causes e.g. `uv build` to not rebuild frontend assets if there are any local changes (CI is not affected).

Since the extensions are inside a monorepo, we need to check for the .git folder one level up.