### PR TITLE
swancontents: Fix preferred_dir interaction with SWAN_projects

### DIFF
--- a/SwanContents/swancontents/filemanager/projects_mixin.py
+++ b/SwanContents/swancontents/filemanager/projects_mixin.py
@@ -28,6 +28,17 @@ class ProjectsMixin(HasTraits):
         help="The base name used when creating untitled projects."
     )
 
+    @property
+    def swan_home(self):
+        """Absolute path to the user home which contains SWAN_projects
+
+        In the classic UI, this is the same as root_dir (typically /eos/user/<u>/<user>).
+        In JupyterLab, the home path is built from root_dir (/eos) and preferred_dir (user/<u>/<user>).
+        """
+        if self.preferred_dir:
+            return os.path.join(self.root_dir, self.preferred_dir)
+        return self.root_dir
+
     def _get_project_path(self, path):
         """ Return the project path where the path provided belongs to """
 
@@ -46,7 +57,7 @@ class ProjectsMixin(HasTraits):
     def _is_swan_root_folder(self, path):
         """ Check is this is SWAN projects folder """
 
-        folders = path.replace(self.root_dir+'/', '', 1).split('/')
+        folders = path.replace(self.swan_home+'/', '', 1).split('/')
         if len(folders) == 2 and folders[0] == self.swan_default_folder:
             return True
 
@@ -55,7 +66,7 @@ class ProjectsMixin(HasTraits):
     def _contains_swan_folder_name(self, path):
         """ To prevent users from using the default SWAN projects folder name """
 
-        folders = path.replace(self.root_dir + '/' + self.swan_default_folder + '/', '', 1).split('/')
+        folders = path.replace(self.swan_home + '/' + self.swan_default_folder + '/', '', 1).split('/')
         for folder in folders:
             if folder == self.swan_default_folder:
                 return True

--- a/SwanContents/swancontents/filemanager/swan_eos_filemanager.py
+++ b/SwanContents/swancontents/filemanager/swan_eos_filemanager.py
@@ -46,7 +46,7 @@ class SwanEosFileManager(ProjectsMixin, SwanFileManagerMixin, AsyncLargeFileMana
         Define the root path for tornado StaticFileHandler object
         This is necessary to open files from other users (for sharing tab)
         """
-        if self.root_dir.startswith("/eos/"):
+        if self.swan_home.startswith("/eos/"):
             return {"path": "/eos/", "default_path": self.root_dir}
         else:
             return {"path": self.root_dir}


### PR DESCRIPTION
SWAN_projects is a special folder in both the classic UI and JupyterLab. Users cannot create and/or rename folders with that name. This was previously enforced with some logic relying on `root_dir` where the hidden assumption was that `root_dir` matches $HOME. This is not the case in JupyterLab where `root_dir` is set to `/eos` and `preferred_dir` is used in conjunction.

The effect was that in JupyterLab it is not possible to rename files inside SWAN_projects. It is also not possible to download files from anywhere.

The fix is to define a new propety `swan_home` which always resolves to the user home.